### PR TITLE
feat: 0.0.2 - Parse stego.lock values to AmbosoEnv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "jobserver",
+ "libc",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +128,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "git2"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +162,16 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -138,6 +188,7 @@ name = "invil"
 version = "0.0.2"
 dependencies = [
  "clap",
+ "git2",
  "log",
  "simplelog",
  "toml",
@@ -150,10 +201,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.16.1+1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -175,6 +275,36 @@ checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "powerfmt"
@@ -298,6 +428,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,16 +477,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "clap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 
 [dependencies]
 clap = { version = "4.4.10", features = ["derive"] }
+git2 = "0.18.1"
 log = "0.4.20"
 simplelog = "0.12.1"
 toml = "0.8.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@
 
 ## What is this thing? <a name = "witt"></a>
 
-  This is a Rust implementation of [amboso](https://github.com/jgabaut/amboso), a basic build tool wrapping make and upporting git tags.
+  This is a Rust implementation of [amboso](https://github.com/jgabaut/amboso), a basic build tool wrapping make and supporting git tags.
 
   It's in a early stage, and there isn't any functionality yet.
 
 ## Supported amboso features <a name = "supported_amboso"></a>
 
   - Basic arguments parsing that complies with the bash implementation
-    - Atm the `verbose` flag expects a `u8` argument, while bash parses multiple flag occurrences.
   - Same default for amboso directory (`./bin`).
 
 ## See how it behaves <a name = "try_anvil"></a>

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -1,1 +1,12 @@
-TODO: parse stego.lock
+[build]
+
+source = "main.rs"
+bin = "invil"
+makevers = "2.0.0"
+automakevers = "3.0.0"
+tests = "kazoj"
+
+[tests]
+
+testsdir = "bone"
+errortestsdir = "kulpo"

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -13,5 +13,5 @@ errortestsdir = "kulpo"
 
 [versions]
 
-"0.0.1" = "First release"
+"-0.0.1" = "First release"
 "0.0.2" = "Draft"

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -10,3 +10,8 @@ tests = "kazoj"
 
 testsdir = "bone"
 errortestsdir = "kulpo"
+
+[versions]
+
+"0.0.1" = "First release"
+"0.0.2" = "Draft"

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,8 +386,8 @@ fn is_git_repo_clean(path: &PathBuf) -> Result<bool, Error> {
         match entry.status() {
             Status::WT_MODIFIED | Status::WT_NEW | Status::INDEX_MODIFIED | Status::INDEX_NEW => {
                 // There are uncommitted changes
-                warn!("Repository has uncommitted changes:");
-                warn!("  {}", entry.path().unwrap());
+                info!("Uncommitted changes:");
+                info!("  {}", entry.path().unwrap());
                 return Ok(false);
             }
             _ => (),
@@ -607,11 +607,11 @@ fn check_passed_args(args: &mut Args) {
             let res = check_amboso_dir(x);
             if res {
                 debug!("Check pass: amboso_dir");
+                debug!("TODO:    Validate amboso_env and use it to set missing arguments");
             } else {
                 error!("Check fail: amboso_dir");
                 return
             }
-            debug!("TODO:    Validate amboso_dir and check its contained stego.lock");
         }
         None => {
             error!("Missing amboso dir argument. Quitting.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -426,10 +426,10 @@ fn check_amboso_dir(dir: &PathBuf) -> Result<AmbosoEnv,String> {
                 }
             }
         } else {
-            return Err(format!("Can't find {}. Quitting", stego_path.display()));
+            return Err(format!("Can't find {}. Quitting.", stego_path.display()));
         }
     } else {
-        return Err(format!("Can't find {}. Quitting", dir.display()));
+        return Err(format!("Can't find {}. Quitting.", dir.display()));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,6 +525,9 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
             if let Some(versions_tab) = y.get("versions").and_then(|v| v.as_table()) {
                 anvil_env.versions_table = versions_tab.iter().map(|(key, value)| (key.to_string(), value.as_str().unwrap().to_string()))
                     .collect();
+                if anvil_env.versions_table.len() == 0 {
+                    warn!("versions_table is empty.");
+                }
             } else {
                 warn!("Missing ANVIL_VERSIONS section.");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use std::{env, fs};
 use simplelog::*;
 use toml::Table;
 use git2::{Repository, Error, Status};
+use std::collections::HashMap;
 
 const INVIL_VERSION: &str = env!("CARGO_PKG_VERSION");
 const INVIL_NAME: &str = env!("CARGO_PKG_NAME");
@@ -170,6 +171,9 @@ struct AmbosoEnv {
 
     /// First tag supporting automake for current project
     mintag_automake: Option<String>,
+
+    /// Table with supported versions and description
+    versions_table: HashMap<String, String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -453,6 +457,7 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
                 tests_dir : None,
                 bonetests_dir : None,
                 kulpotests_dir : None,
+                versions_table: HashMap::new(),
             };
             trace!("Toml value: {{{}}}", y);
             let build_section = y["build"].as_table();
@@ -518,6 +523,13 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
                 }
             } else {
                 warn!("Missing ANVIL_TESTS section.");
+            }
+            let versions_section = y["versions"].as_table();
+            if let Some(versions_tab) = versions_section {
+                anvil_env.versions_table = versions_tab.iter().map(|(key, value)| (key.to_string(), value.as_str().unwrap().to_string()))
+                    .collect();
+            } else {
+                warn!("Missing ANVIL_VERSIONS section.");
             }
             return Ok(anvil_env);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,13 @@ use toml::Table;
 
 const INVIL_VERSION: &str = env!("CARGO_PKG_VERSION");
 const INVIL_NAME: &str = env!("CARGO_PKG_NAME");
+const ANVIL_SOURCE_KEYNAME: &str = "source";
+const ANVIL_BIN_KEYNAME: &str = "bin";
+const ANVIL_MAKE_VERS_KEYNAME: &str = "makevers";
+const ANVIL_AUTOMAKE_VERS_KEYNAME: &str = "automakevers";
+const ANVIL_TESTSDIR_KEYNAME: &str = "tests";
+const ANVIL_BONEDIR_KEYNAME: &str = "testsdir";
+const ANVIL_KULPODIR_KEYNAME: &str = "errortestsdir";
 
 
 #[derive(Parser, Debug)]
@@ -392,7 +399,52 @@ fn check_passed_args(args: &mut Args) {
                 let toml_value = x_contents.parse::<Table>();
                 match toml_value {
                     Ok(y) => {
-                        debug!("Toml value: {{{}}}", y);
+                        trace!("Toml value: {{{}}}", y);
+                        let build_section = y["build"].as_table();
+                        if let Some(build_table) = build_section {
+                            if let Some(source_name) = build_table.get(ANVIL_SOURCE_KEYNAME) {
+                                debug!("ANVIL_SOURCE: {{{source_name}}}");
+                            } else {
+                                warn!("Missing ANVIL_SOURCE definition.");
+                            }
+                            if let Some(binary_name) = build_table.get(ANVIL_BIN_KEYNAME) {
+                                debug!("ANVIL_BIN: {{{binary_name}}}");
+                            } else {
+                                warn!("Missing ANVIL_BIN definition.");
+                            }
+                            if let Some(anvil_make_vers_tag) = build_table.get(ANVIL_MAKE_VERS_KEYNAME) {
+                                debug!("ANVIL_MAKE_VERS: {{{anvil_make_vers_tag}}}");
+                            } else {
+                                warn!("Missing ANVIL_MAKE_VERS definition.");
+                            }
+                            if let Some(anvil_automake_vers_tag) = build_table.get(ANVIL_AUTOMAKE_VERS_KEYNAME) {
+                                debug!("ANVIL_AUTOMAKE_VERS: {{{anvil_automake_vers_tag}}}");
+                            } else {
+                                warn!("Missing ANVIL_AUTOMAKE_VERS definition.");
+                            }
+                            if let Some(anvil_testsdir) = build_table.get(ANVIL_TESTSDIR_KEYNAME) {
+                                debug!("ANVIL_TESTDIR: {{{anvil_testsdir}}}");
+                            } else {
+                                warn!("Missing ANVIL_TESTDIR definition.");
+                            }
+                        } else {
+                            warn!("Missing ANVIL_BUILD section.");
+                        }
+                        let tests_section = y["tests"].as_table();
+                        if let Some(tests_table) = tests_section {
+                            if let Some(anvil_bonetests_dir) = tests_table.get(ANVIL_BONEDIR_KEYNAME) {
+                                debug!("ANVIL_BONEDIR: {{{anvil_bonetests_dir}}}");
+                            } else {
+                                warn!("Missing ANVIL_BONEDIR definition.");
+                            }
+                            if let Some(anvil_kulpotests_dir) = tests_table.get(ANVIL_KULPODIR_KEYNAME) {
+                                debug!("ANVIL_KULPODIR: {{{anvil_kulpotests_dir}}}");
+                            } else {
+                                warn!("Missing ANVIL_KULPODIR definition.");
+                            }
+                        } else {
+                            warn!("Missing ANVIL_TESTS section.");
+                        }
                         return
                     }
                     Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,8 +538,6 @@ fn check_passed_args(args: &mut Args) {
         return
     }
 
-    print_grouped_args(&args);
-
     match args.gen_c_header {
         Some(ref x) => {
             info!("C header dir: {{{}}}", x.display());
@@ -575,6 +573,12 @@ fn check_passed_args(args: &mut Args) {
             trace!("-x not asserted.");
         }
     }
+
+    if ! args.base && ! args.test && ! args.testmacro {
+        args.git = true;
+    }
+
+    print_grouped_args(&args);
 
     //Process env arguments
     if args.ignore_gitcheck || ! args.git{

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,6 +532,7 @@ fn check_passed_args(args: &mut Args) {
 
     if args.warranty {
         print_warranty_info();
+        return
     }
     if args.version {
         println!("{}",INVIL_VERSION);

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,7 +553,7 @@ fn check_passed_args(args: &mut Args) {
     }
 
     //Process env arguments
-    if args.ignore_gitcheck {
+    if args.ignore_gitcheck || ! args.git{
         info!("Ignoring git check.");
     } else {
         todo!("Gitcheck function");

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,8 +172,14 @@ struct AmbosoEnv {
     /// First tag supporting automake for current project
     mintag_automake: Option<String>,
 
-    /// Table with supported versions and description
+    /// Table with all supported versions and description
     versions_table: HashMap<String, String>,
+
+    /// Table with supported versions for base mode and description
+    basemode_versions_table: HashMap<String, String>,
+
+    /// Table with supported versions for git mode and description
+    gitmode_versions_table: HashMap<String, String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -457,7 +463,9 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
                 tests_dir : None,
                 bonetests_dir : None,
                 kulpotests_dir : None,
-                versions_table: HashMap::new(),
+                versions_table: HashMap::with_capacity(100),
+                basemode_versions_table: HashMap::with_capacity(50),
+                gitmode_versions_table: HashMap::with_capacity(50),
             };
             trace!("Toml value: {{{}}}", y);
             if let Some(build_table) = y.get("build").and_then(|v| v.as_table()) {
@@ -527,6 +535,15 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
                     .collect();
                 if anvil_env.versions_table.len() == 0 {
                     warn!("versions_table is empty.");
+                } else {
+                    for (key, value) in anvil_env.versions_table.iter() {
+                        if key.starts_with('-') {
+                            let trimmed_key = key.trim_start_matches('-').to_string();
+                            anvil_env.basemode_versions_table.insert(trimmed_key, value.clone());
+                        } else {
+                            anvil_env.gitmode_versions_table.insert(key.clone(), value.clone());
+                        }
+                    }
                 }
             } else {
                 warn!("Missing ANVIL_VERSIONS section.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -460,8 +460,7 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
                 versions_table: HashMap::new(),
             };
             trace!("Toml value: {{{}}}", y);
-            let build_section = y["build"].as_table();
-            if let Some(build_table) = build_section {
+            if let Some(build_table) = y.get("build").and_then(|v| v.as_table()) {
                 if let Some(source_name) = build_table.get(ANVIL_SOURCE_KEYNAME) {
                     trace!("ANVIL_SOURCE: {{{source_name}}}");
                     anvil_env.source = Some(format!("{}", source_name.as_str().expect("toml conversion failed")));
@@ -499,8 +498,7 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
             } else {
                 warn!("Missing ANVIL_BUILD section.");
             }
-            let tests_section = y["tests"].as_table();
-            if let Some(tests_table) = tests_section {
+            if let Some(tests_table) = y.get("tests").and_then(|v| v.as_table()) {
                 if let Some(anvil_bonetests_dir) = tests_table.get(ANVIL_BONEDIR_KEYNAME) {
                     trace!("ANVIL_BONEDIR: {{{anvil_bonetests_dir}}}");
                     let mut path = PathBuf::new();
@@ -524,8 +522,7 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
             } else {
                 warn!("Missing ANVIL_TESTS section.");
             }
-            let versions_section = y["versions"].as_table();
-            if let Some(versions_tab) = versions_section {
+            if let Some(versions_tab) = y.get("versions").and_then(|v| v.as_table()) {
                 anvil_env.versions_table = versions_tab.iter().map(|(key, value)| (key.to_string(), value.as_str().unwrap().to_string()))
                     .collect();
             } else {


### PR DESCRIPTION
- Add `AmbosoEnv` struct definition
- Add basic logic to parse `stego.lock` as `toml`
- Add `is_git_repo_clean()` to check if working directory status when in git mode
- Set `git` to `true` when not doing `linter` or `gen_c_header` and no other mode was specified
- Return early on calls with `-W`
- Bump version to `0.0.2`