### PR TITLE
feat: return AmbosoEnv from check_passed_args()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 
 ### Changed
 
+- Extended AmbosoEnv, now includes runmode, selected ops, testmode and makemode support for the run
 - Moved some output to trace level
 - main() returns ExitCode
 - check_passed_args() returns Result<AmbosoEnv,String>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,45 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.0.3] - 2023-11-30
+
+### Added
+
+- AmbosoMode enum definition
+- Basic logic to set anvil_env/args value
+- Stub handle_amboso_env()
+
+### Fixed
+
+- Added changelog to repo
+
+### Changed
+
+- Moved some output to trace level
+- main() returns ExitCode
+- check_passed_args() returns Result<AmbosoEnv,String>
+
+## [0.0.2] - 2023-11-29
+
+### Added
+
+- AmbosoEnv struct definition
+- Basic logic to parse amboso_dir/stego.lock as toml
+- is_git_repo_clean() to check if working dir status when in git mode
+
+### Fixed
+
+- Set args.git to true when no other runmode is specified
+
+### Changed
+
+- Return early on calls with warranty flag
+- Upgrade dependencies: clap 4.4.10
+
+## [0.0.1] - 2023-11-28
+
+### Added
+
+- Basic argument parsing that mostly complies with the bash implementation
+- Default for amboso directory ("./bin")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
   - Basic arguments parsing that complies with the bash implementation
   - Same default for amboso directory (`./bin`).
+  - Parse `stego.lock` with compatible logic to bash implementation
 
 ## See how it behaves <a name = "try_anvil"></a>
 
@@ -34,7 +35,6 @@ Our version was slightly modified to actually make cargo build the release versi
 
 ## Todo <a name = "todo"></a>
 
-  - Parse `stego.lock` with compatible logic to bash implementation
   - Check all runtime values are valid before op checks
   - Implement control flow for op checks
   - Implement quiet, verbose, silent functionality

--- a/src/main.rs
+++ b/src/main.rs
@@ -740,8 +740,15 @@ fn check_passed_args(args: &mut Args) {
             debug!("TODO:  Validate source")
         }
         None => {
-            warn!("Missing source arg.");
-            args.source = anvil_env.source;
+            match anvil_env.source {
+                Some(x) => {
+                    args.source = Some(x);
+                }
+                None => {
+                    error!("Missing source arg. Quitting.");
+                    return
+                }
+            }
             debug!("TODO:  Validate source")
         }
     }
@@ -754,10 +761,20 @@ fn check_passed_args(args: &mut Args) {
         }
         None => {
             warn!("Missing execname arg.");
-            args.execname = anvil_env.bin;
+            match anvil_env.bin {
+                Some(x) => {
+                    args.execname = Some(x);
+                }
+                None => {
+                    error!("Missing execname arg. Quitting.");
+                    return
+                }
+            }
             debug!("TODO:  Validate execname")
         }
     }
+
+    let mut support_makemode = true;
 
     match &args.maketag {
         Some(x) => {
@@ -767,10 +784,23 @@ fn check_passed_args(args: &mut Args) {
         }
         None => {
             warn!("Missing maketag arg.");
-            args.maketag = anvil_env.mintag_make;
-            debug!("TODO:    Get maketag arg from stego.lock");
+            match anvil_env.mintag_make {
+                Some(x) => {
+                    args.maketag = Some(x);
+                }
+                None => {
+                    warn!("Missing maketag arg.");
+                    support_makemode = false;
+                }
+            }
         }
     }
+    let makemode_support_text = match support_makemode {
+        true => "Make mode is supported",
+        false => "Make mode is not supported",
+    };
+    trace!("{}", makemode_support_text);
+
     todo!("Check all required arguments are usable, and if they aren't either set them or fail");
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,9 @@ struct AmbosoEnv {
     /// Do purge op
     do_purge: bool,
 
+    /// Report build status op
+    do_query: bool,
+
     /// Allow make builds
     support_makemode: bool,
 }
@@ -503,6 +506,7 @@ fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
                 do_delete : false,
                 do_init : false,
                 do_purge : false,
+                do_query : false,
             };
             trace!("Toml value: {{{}}}", y);
             if let Some(build_table) = y.get("build").and_then(|v| v.as_table()) {
@@ -616,6 +620,7 @@ fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
         do_delete : false,
         do_init : false,
         do_purge : false,
+        do_query : false,
     };
 
     if args.warranty {
@@ -860,6 +865,7 @@ fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
     anvil_env.do_delete = args.delete;
     anvil_env.do_init = args.init;
     anvil_env.do_purge = args.purge;
+    anvil_env.do_query = true;
 
     return Ok(anvil_env);
 }
@@ -873,6 +879,11 @@ fn print_warranty_info() {
   PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
   IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
   ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n");
+}
+
+fn handle_amboso_env(env: AmbosoEnv) {
+
+    info!("Runmode: {:?}", env.run_mode);
 }
 
 fn main() -> ExitCode {
@@ -900,8 +911,9 @@ fn main() -> ExitCode {
     let res_check = check_passed_args(&mut args);
 
     match res_check {
-        Ok(_) => {
+        Ok(env) => {
             info!("check_passed_args() success");
+            handle_amboso_env(env);
             return ExitCode::SUCCESS;
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -690,8 +690,7 @@ fn check_passed_args(args: &mut Args) {
             debug!("TODO:    Validate kazoj_dir");
         }
         None => {
-            warn!("Missing tests dir.");
-            trace!("Checking if stego.lock had a valid tests_dir path");
+            warn!("Missing tests dir. Checking if stego.lock had a valid tests_dir path");
             match anvil_env.tests_dir {
                 Some(x) => {
                     if x.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,11 +418,11 @@ fn is_git_repo_clean(path: &PathBuf) -> Result<bool, Error> {
 
 fn check_amboso_dir(dir: &PathBuf) -> Result<AmbosoEnv,String> {
     if dir.exists() {
-        info!("Found {}", dir.display());
+        trace!("Found {}", dir.display());
         let mut stego_path = dir.clone();
         stego_path.push("stego.lock");
         if stego_path.exists() {
-            info!("Found {}", stego_path.display());
+            trace!("Found {}", stego_path.display());
             let res = parse_stego_toml(&stego_path);
             match res {
                 Ok(a) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -739,7 +739,7 @@ fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
             debug!("TODO:    Validate kazoj_dir");
         }
         None => {
-            warn!("Missing tests dir. Checking if stego.lock had a valid tests_dir path");
+            trace!("Missing tests dir. Checking if stego.lock had a valid tests_dir path");
             match anvil_env.tests_dir {
                 Some(ref x) => {
                     if x.exists() {
@@ -788,7 +788,7 @@ fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
             debug!("TODO:  Validate source")
         }
         None => {
-            warn!("Missing source arg. Checking if stego.lock had a valid source value");
+            trace!("Missing source arg. Checking if stego.lock had a valid source value");
             match anvil_env.source {
                 Some( ref x) => {
                     args.source = Some(x.clone());
@@ -809,7 +809,7 @@ fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
             debug!("TODO:  Validate execname")
         }
         None => {
-            warn!("Missing execname arg. Checking if stego.lock had a valid bin value");
+            trace!("Missing execname arg. Checking if stego.lock had a valid bin value");
             match anvil_env.bin {
                 Some(ref x) => {
                     args.execname = Some(x.clone());
@@ -830,7 +830,7 @@ fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
             debug!("TODO:  Validate maketag")
         }
         None => {
-            warn!("Missing maketag arg. Checking if stego.lock had a valid bin value");
+            trace!("Missing maketag arg. Checking if stego.lock had a valid bin value");
             match anvil_env.mintag_make {
                 Some( ref x) => {
                     args.maketag = Some(x.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -858,6 +858,8 @@ fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
         anvil_env.run_mode = Some(AmbosoMode::TestMode);
     } else if args.testmacro {
         anvil_env.run_mode = Some(AmbosoMode::TestMacro);
+    } else {
+        panic!("No mode flag was asserted");
     }
 
     anvil_env.do_build = args.build;
@@ -883,7 +885,7 @@ fn print_warranty_info() {
 
 fn handle_amboso_env(env: AmbosoEnv) {
 
-    info!("Runmode: {:?}", env.run_mode);
+    info!("Runmode: {:?}", env.run_mode.unwrap());
 }
 
 fn main() -> ExitCode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -731,11 +731,12 @@ fn check_passed_args(args: &mut Args) {
         true => "Test mode is supported",
         false => "Test mode is not supported",
     };
-    debug!("{}", testmode_support_text);
+    trace!("{}", testmode_support_text);
 
     match args.source {
         Some(ref x) => {
             info!("Source {{{}}}", x);
+            anvil_env.source = args.source.clone();
             debug!("TODO:  Validate source")
         }
         None => {
@@ -745,9 +746,10 @@ fn check_passed_args(args: &mut Args) {
         }
     }
 
-    match args.execname {
-        Some(ref x) => {
+    match &args.execname {
+        Some(x) => {
             info!("Execname {{{}}}", x);
+            anvil_env.bin = Some(x.to_string());
             debug!("TODO:  Validate execname")
         }
         None => {
@@ -757,13 +759,15 @@ fn check_passed_args(args: &mut Args) {
         }
     }
 
-    match args.maketag {
-        Some(ref x) => {
+    match &args.maketag {
+        Some(x) => {
             info!("Maketag {{{}}}", x);
+            anvil_env.mintag_make = Some(x.to_string());
             debug!("TODO:  Validate maketag")
         }
         None => {
             warn!("Missing maketag arg.");
+            args.maketag = anvil_env.mintag_make;
             debug!("TODO:    Get maketag arg from stego.lock");
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -426,7 +426,7 @@ fn check_amboso_dir(dir: &PathBuf) -> Result<AmbosoEnv,String> {
             let res = parse_stego_toml(&stego_path);
             match res {
                 Ok(a) => {
-                    debug!("Stego contents: {{{:#?}}}", a);
+                    trace!("Stego contents: {{{:#?}}}", a);
                     return Ok(a);
                 }
                 Err(e) => {


### PR DESCRIPTION
- Extend `AmbosoEnv`
- Set `AmbosoEnv` field to return it from `check_passed_args()`
- Add `AmbosoMode`
- Stub `handle_amboso_env()`
- Bump version to `0.0.3`