### PR TITLE
feat: 0.0.4 Add do_query()

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "clap*"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,46 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.0.3] - 2023-11-30
+
+### Added
+
+- AmbosoMode enum definition
+- Basic logic to set anvil_env/args value
+- Stub handle_amboso_env()
+
+### Fixed
+
+- Added changelog to repo
+
+### Changed
+
+- Extended AmbosoEnv, now includes runmode, selected ops, testmode and makemode support for the run
+- Moved some output to trace level
+- main() returns ExitCode
+- check_passed_args() returns Result<AmbosoEnv,String>
+
+## [0.0.2] - 2023-11-29
+
+### Added
+
+- AmbosoEnv struct definition
+- Basic logic to parse amboso_dir/stego.lock as toml
+- is_git_repo_clean() to check if working dir status when in git mode
+
+### Fixed
+
+- Set args.git to true when no other runmode is specified
+
+### Changed
+
+- Return early on calls with warranty flag
+- Upgrade dependencies: clap 4.4.10
+
+## [0.0.1] - 2023-11-28
+
+### Added
+
+- Basic argument parsing that mostly complies with the bash implementation
+- Default for amboso directory ("./bin")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add stub op checks for build, run, delete, init, purge
+- Add do_query(), checking if requested tag is in supported versions
+- Add functionality for -l and -L
+- Add functionality for -V
+
+### Fixed
+
+- Fix panic on unwrapping AmbosoEnv.run_mode
+
+### Changed
+
+- handle_amboso_env() takes Args
+
 ## [0.0.3] - 2023-11-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
   - Basic arguments parsing that complies with the bash implementation
   - Same default for amboso directory (`./bin`).
+  - Parse `stego.lock` with compatible logic to bash implementation
 
 ## See how it behaves <a name = "try_anvil"></a>
 
@@ -34,7 +35,6 @@ Our version was slightly modified to actually make cargo build the release versi
 
 ## Todo <a name = "todo"></a>
 
-  - Parse `stego.lock` with compatible logic to bash implementation
   - Check all runtime values are valid before op checks
   - Implement control flow for op checks
   - Implement quiet, verbose, silent functionality

--- a/README.md
+++ b/README.md
@@ -21,6 +21,35 @@
   - Same default for amboso directory (`./bin`).
   - Parse `stego.lock` with compatible logic to bash implementation
 
+  Flags support status:
+
+  - [x] Basic env flags:  `-D`, `-K`, `-M`, `-S`, `-E`
+  - [ ] Clock flag: `-C <startTime>`
+  - [x] Linter mode: `-x`
+    - [ ] Lint only: `-l`
+    - [ ] Report lex: `-L`
+  - [ ] C header gen mode: `-G`
+  - [x] Verbose flag: `-V`
+  - [ ] Test macro: `-t`
+  - [ ] Test mode: `-T`
+  - [ ] Git mode: `-g`
+  - [ ] Base mode: `-B`
+  - [ ] Build: `-b`
+  - [ ] Run: `-r`
+  - [ ] Init: `-i`
+  - [ ] Delete: `-d`
+  - [ ] Purge: `-p`
+  - [x] Help: `-h`
+  - [ ] Big Help: `-H`
+  - [x] Version: `-v`
+  - [x] List tags for current mode: `-l`
+  - [x] List tags for git/base mode: `-L`
+  - [ ] Quiet flag: `-q`
+  - [ ] CFG flag: `-c`
+  - [ ] Watch flag: `-w`
+  - [x] Warranty flag: `-W`
+  - [x] Ignore gitcheck flag: `-X`
+
 ## See how it behaves <a name = "try_anvil"></a>
 
 To see how this marvelous work of art works, run:


### PR DESCRIPTION
- Fixes panic on unwrapping `AmbosoEnv.run_mode`
- Add stub op checks
- Add `do_query()`, checking if requested tag is in supported versions
- `handle_amboso_env()` takes `Args`
- Add `-l` and `-L` functionality to print supported tags
- Add `-V` functionality to set loglevel