### PR TITLE
feat: support for autotools prep step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [Unreleased]
+## [0.0.8] - 2023-12-06
+
+### Added
+
+- Support for automake mode
+  - Naive command to prep autotools
+
+### Changed
+
+- Permit run op for Gitmode
+
+## [0.0.7] - 2023-12-06
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 + [What is this thing?](#witt)
 + [Supported amboso features](#supported_amboso)
 + [See how it behaves](#try_anvil)
++ [Basic benchmark](#base_bench)
 + [Todo](#todo)
 
 ## What is this thing? <a name = "witt"></a>
@@ -24,9 +25,8 @@
   - Parse `stego.lock` with compatible logic to bash implementation
   - Base mode: full support
     - The original implementation itself does not expect autotools prep for base mode, but it can be done trivially.
-  - Git mode: make support
+  - Git mode: full support
     - The original implementation itself expects git mode tags to contain a `Makefile` in repo root.
-    - autotools prep is not supported yet
 
   Flags support status:
 
@@ -69,14 +69,17 @@ Refer to amboso info about this test script: [link](https://github.com/jgabaut/a
 
 Our version was slightly modified to actually make cargo build the release version of the binary we want to symlink to `anvil`.
 
+## Basic benchmark <a name = "base_bench"></a>
+
+Check out [this page](https://github.com/jgabaut/invil/bench/gitmode-bench.md) for a very basic benchmark of runtime, relative to bash `amboso` implementation.
+
 ## Todo <a name = "todo"></a>
 
-  - Implement autotools prep step
   - Implement test mode
   - Implement silent functionality
   - Extend original impl by handling autotools in base mode
   - Improve logging with a custom format
   - Improve horrendous git mode command chain
+    - The current implementation is naive and just calls a bunch of `Command` to pipeline the git operations in a ugly iper-indented mess.
     - Resorting to shell commands is bad and defeats the purpose of this rewrite.
     - We have git2 crate to handle the git commands and should be able to reduce the amount of command wrapping.
-    - Handle autotools prep

--- a/bench/gitmode-bench.md
+++ b/bench/gitmode-bench.md
@@ -1,0 +1,40 @@
+Benchmark done on [koliseo](https://github.com/jgabaut/koliseo) repo.
+
+This is on default mode (git).
+
+## NOTE:
+ - Only one run was done, better averaging will be needed.
+
+To replicate this naive bench:
+- Install amboso and invil as bin program
+- cd `koliseo_git_repo`
+- `time anvil -i`
+- `time anvil -p`
+- `time invil -i`
+- `time invil -p`
+
+## Purge
+
+| Implementation | Operation          | Time |
+| ------- | ------------------ | ------- |
+| invil 0.0.8| purge |real	0m0,530s |
+| amboso 1.9.6| purge |real	0m36,729s|
+
+### Improvement
+
+ - Runtime: `***(-98,55%)***`
+ - Diff: `36,199s`
+
+
+## Init
+
+
+| Implementation | Operation          | Time |
+| ------- | ------------------ | ------- |
+| invil 0.0.8| init |real	4m9,765s|
+| amboso 1.9.6| init |real	6m54,603s|
+
+### Improvement
+
+ - Runtime: `***(-39,75%)***`
+ - Diff: `2m44,838s`

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -15,3 +15,4 @@ errortestsdir = "kulpo"
 
 "-0.0.5" = "First release supporting base mode build. gcc call only"
 "-0.0.7" = "First release supporting base mode build. Wrap make"
+"0.0.8" = "First tag available in git mode."

--- a/bin/v0.0.8/.gitignore
+++ b/bin/v0.0.8/.gitignore
@@ -1,0 +1,3 @@
+#amboso compliant version folder, will ignore everything inside BUT the gitignore and needed files, to keep the clean dir
+*
+!.gitignore

--- a/src/main.rs
+++ b/src/main.rs
@@ -1258,13 +1258,10 @@ fn do_run(env: &AmbosoEnv, args: &Args) -> Result<String,String> {
         Some(ref q) => {
             match env.run_mode.as_ref().unwrap() {
                 AmbosoMode::GitMode => {
-                    todo!("Run op for git mode");
-                    /*
                     if ! env.gitmode_versions_table.contains_key(q) {
                         error!("{{{}}} was not a valid tag.",q);
                         return Err("Invalid tag".to_string())
                     }
-                    */
                 }
                 AmbosoMode::BaseMode => {
                     if ! env.basemode_versions_table.contains_key(q) {


### PR DESCRIPTION
- Add `autotools` prep step to support reference `Gitmode`
  - Naive implementation just doing `Command::new()`
- Allow `-r` in `Gitmode`
- Update `CHANGELOG`
- Add `bench/gitmode-bench.md`