### PR TITLE
feat: add -C to read config from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- C header now includes head info for repo
+- C header now includes:
+  - head info for repo (somewhat compliant with original implementation)
+  - commit message as a string (in extended header section)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- C header now includes head info for repo
+
 ## [0.1.3] - 2023-12-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - C header now includes head info for repo
 
+### Changed
+
+- Define EXPECTED_AMBOSO_API_LEVEL
+
+- C header is no longer generated with flat 1.9.6
+
 ## [0.1.3] - 2023-12-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - commit message as a string (in extended header section)
 - --no-color extension to turn off color output
 
+- New -C flag to pass config file (contents used for config call during autotools prep)
+
 ### Changed
 
 - Define EXPECTED_AMBOSO_API_LEVEL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.4] - 2023-12-15
 
 ### Added
 
@@ -10,6 +10,10 @@
 - --no-color extension to turn off color output
 
 - New -C flag to pass config file (contents used for config call during autotools prep)
+
+### Fixed
+
+- C header is no longer generating with "helapordo" in some places
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - C header now includes:
   - head info for repo (somewhat compliant with original implementation)
   - commit message as a string (in extended header section)
+- --no-color extension to turn off color output
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.1.3"
+version = "0.1.4-dev"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.1.3"
+version = "0.1.4-dev"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
   - [x] `-G` flag also includes:
     - a string for build OS (from `env::consts::OS`)
     - HEAD commit message
+  - [x] `--no-color` to disable color output
 
 ## See how it behaves <a name = "try_anvil"></a>
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
     - The original implementation itself does not expect autotools prep for base mode, but it can be done trivially.
   - Git mode: full support
     - The original implementation itself expects git mode tags to contain a `Makefile` in repo root.
-  - C header gen: basic support
-    - The original implementation also prepares git commit info for the header.
+  - C header gen: complete support (\*)
+    - The original implementation print time as a pre-formatted string.
   - Test mode: complete support (\*)
     - Run executable found in test directories
     - Handle test macro flag to run on all valid queries
@@ -73,8 +73,9 @@
 
   - [x] `--logged` to output full log to file
     - Outputs to `./invil.log`. Not backwards compatible with repos not ignoring the file explicitly.
-  - [x] `-G` flag also includes a string for build OS.
-    - From `env::consts::OS`
+  - [x] `-G` flag also includes:
+    - a string for build OS (from `env::consts::OS`)
+    - HEAD commit message
 
 ## See how it behaves <a name = "try_anvil"></a>
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,17 @@
     - Handle test macro flag to run on all valid queries
     - Record test output with `-b`
       - Not compliant with amboso <1.9.7 expectations: missing trailing `$`.
+  - Passing configure arguments: (\*)
+    - Amboso 1.9.8 expects -C flag to be passing the arguments directly, not by reading a file.
   - Subcommands:
     - build    Quickly build latest version for current mode
     - init     Prepare new project with amboso
+    - version  Print invil version
 
   Flags support status:
 
   - [x] Basic env flags:  `-D`, `-K`, `-M`, `-S`, `-E`
-  - [ ] Clock flag: `-C <startTime>`
+  - [ ] Clock flag: `-Y <startTime>`
   - [x] Linter mode: `-x`
     - [ ] Lint only: `-l`
     - [ ] Report lex: `-L`
@@ -67,6 +70,7 @@
   - [x] Warranty flag: `-W`
   - [x] Ignore gitcheck flag: `-X`
   - [ ] Silent: `-s`
+  - [ ] Pass config argument: `-C`
 
 
 ## Extensions

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
   - [x] Warranty flag: `-W`
   - [x] Ignore gitcheck flag: `-X`
   - [ ] Silent: `-s`
-  - [ ] Pass config argument: `-C`
+  - [ ] Pass config argument: `-C` (See above)
 
 
 ## Extensions

--- a/src/core.rs
+++ b/src/core.rs
@@ -150,6 +150,10 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub logged: bool,
 
+    /// Disable color output
+    #[arg(long, default_value = "false")]
+    pub no_color: bool,
+
     //TODO: Handle -C flag for passing start time for recursive calls
 
     /// Subcommand

--- a/src/core.rs
+++ b/src/core.rs
@@ -38,6 +38,7 @@ pub const ANVIL_AUTOMAKE_VERS_KEYNAME: &str = "automakevers";
 pub const ANVIL_TESTSDIR_KEYNAME: &str = "tests";
 pub const ANVIL_BONEDIR_KEYNAME: &str = "testsdir";
 pub const ANVIL_KULPODIR_KEYNAME: &str = "errortestsdir";
+pub const EXPECTED_AMBOSO_API_LEVEL: &str = "1.9.7";
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about = format!("{} - A simple build tool leveraging make", INVIL_NAME), long_about = format!("{} - A drop-in replacement for amboso", INVIL_NAME), disable_version_flag = true)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -154,6 +154,10 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub no_color: bool,
 
+    /// Pass configuration argument
+    #[arg(short = 'C', long, value_name = "CONFIG_ARG")]
+    pub config: Option<String>,
+
     //TODO: Handle -C flag for passing start time for recursive calls
 
     /// Subcommand
@@ -206,6 +210,9 @@ pub struct AmbosoEnv {
 
     /// Table with supported versions for git mode and description
     pub gitmode_versions_table: BTreeMap<String, String>,
+
+    /// String used for configure command argument
+    pub configure_arg: String,
 
     /// Allow test mode run
     pub support_testmode: bool,
@@ -736,6 +743,7 @@ pub fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
                 do_init : false,
                 do_purge : false,
                 start_time: start_time,
+                configure_arg: "".to_string(),
             };
             trace!("Toml value: {{{}}}", y);
             if let Some(build_table) = y.get("build").and_then(|v| v.as_table()) {
@@ -1154,7 +1162,25 @@ pub fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
         do_init : false,
         do_purge : false,
         start_time: start_time,
+        configure_arg: "".to_string(),
     };
+
+    match args.config {
+        Some (ref x) => {
+            let config_read_res = fs::read_to_string(x);
+            match config_read_res {
+                Ok(config_str) => {
+                    trace!("Read config file: {{{}}}", config_str);
+                    anvil_env.configure_arg = config_str;
+                }
+                Err(e) => {
+                    error!("Failed reading config file from {{{}}}. Err: {e}", x);
+                    return Err("Failed reading config file".to_string());
+                }
+            }
+        }
+        None => {}
+    }
 
     match args.linter {
         Some(ref x) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,18 +85,29 @@ fn main() -> ExitCode {
         .set_thread_mode(ThreadLogMode::Both)
         .build();
 
+    let color_choice;
+
+    match args.no_color {
+        true => {
+            color_choice = ColorChoice::Never;
+        }
+        false => {
+            color_choice = ColorChoice::Always;
+        }
+    }
+
     match args.logged {
         false => {
             CombinedLogger::init(
                 vec![
-                    TermLogger::new(log_level, config, TerminalMode::Mixed, ColorChoice::Always),
+                    TermLogger::new(log_level, config, TerminalMode::Mixed, color_choice),
                 ]
             ).unwrap();
         }
         true => {
             CombinedLogger::init(
                 vec![
-                TermLogger::new(log_level, config.clone(), TerminalMode::Mixed, ColorChoice::Always),
+                TermLogger::new(log_level, config.clone(), TerminalMode::Mixed, color_choice),
                 WriteLogger::new(LevelFilter::Trace, config, File::create(INVIL_LOG_FILE).unwrap()),
                 ]
             ).unwrap();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -818,6 +818,7 @@ pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &Strin
     let mut head_author_name = "".to_string();
     let id;
     let commit_time;
+    let mut commit_message = "".to_string();
     match repo {
         Ok(r) => {
             let head = r.head();
@@ -826,6 +827,10 @@ pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &Strin
                     let commit = head.peel_to_commit();
                     match commit {
                        Ok(commit) => {
+                           if let Some(msg) = commit.message() {
+                               info!("Commit message: {{{}}}", msg);
+                               commit_message = msg.escape_default().to_string();
+                           }
                            id = commit.id().to_string();
                            info!("Commit id: {{{}}}", id);
                            let author = commit.author();
@@ -880,8 +885,10 @@ const char *get_ANVIL__VERSION__AUTHOR(void); /**< Returns a version author stri
 #define INVIL__{bin_name}__HEADER__
 static const char INVIL__VERSION__STRING[] = \"{INVIL_VERSION}\"; /**< Represents invil version used for [anvil__{bin_name}.h] generated header.*/\n
 static const char INVIL__OS__STRING[] = \"{INVIL_OS}\"; /**< Represents build os used for [anvil__{bin_name}.h] generated header.*/\n
+static const char INVIL__COMMIT__DESC__STRING[] = \"{commit_message}\"; /**< Represents message for HEAD commit used for [anvil__{bin_name}.h] generated header.*/\n
 const char *get_INVIL__API__LEVEL__(void); /**< Returns a version string for invil version of [anvil__{bin_name}.h] generated header.*/\n
 const char *get_INVIL__OS__(void); /**< Returns a version string for os used for [anvil__{bin_name}.h] generated header.*/\n
+const char *get_INVIL__COMMIT__DESC__(void); /**< Returns a string for HEAD commit message used for [anvil__{bin_name}.h] generated header.*/\n
 #endif // INVIL__{bin_name}__HEADER__
 #endif");
     match output {
@@ -929,6 +936,10 @@ const char *get_ANVIL__VERSION__AUTHOR__(void)
 const char *get_INVIL__API__LEVEL__(void)
 {{
     return INVIL__VERSION__STRING;
+}}\n
+const char *get_INVIL__COMMIT__DESC__(void)
+{{
+    return INVIL__COMMIT__DESC__STRING;
 }}\n
 const char *get_INVIL__OS__(void)
 {{

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -922,15 +922,15 @@ const char *get_ANVIL__API__LEVEL__(void)
 }}\n
 const char *get_ANVIL__VERSION__DESC__(void)
 {{
-    return ANVIL__helapordo__VERSION_DESC;
+    return ANVIL__{bin_name}__VERSION_DESC;
 }}\n
 const char *get_ANVIL__VERSION__DATE__(void)
 {{
-    return ANVIL__helapordo__VERSION_DATE;
+    return ANVIL__{bin_name}__VERSION_DATE;
 }}\n
 const char *get_ANVIL__VERSION__AUTHOR__(void)
 {{
-    return ANVIL__helapordo__VERSION_AUTHOR;
+    return ANVIL__{bin_name}__VERSION_AUTHOR;
 }}\n
 #ifdef INVIL__{bin_name}__HEADER__
 const char *get_INVIL__API__LEVEL__(void)

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -11,7 +11,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use crate::core::{Args, AmbosoEnv, AmbosoMode, INVIL_VERSION, INVIL_OS};
+use crate::core::{Args, AmbosoEnv, AmbosoMode, INVIL_VERSION, INVIL_OS, EXPECTED_AMBOSO_API_LEVEL};
 use std::process::Command;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -866,7 +866,7 @@ pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &Strin
 //Repo at https://github.com/jgabaut/invil\n
 #ifndef ANVIL__{bin_name}__\n
 #define ANVIL__{bin_name}__\n
-static const char ANVIL__API_LEVEL__STRING[] = \"1.9.6\"; /**< Represents amboso version used for [anvil__{bin_name}.h] generated header.*/\n
+static const char ANVIL__API_LEVEL__STRING[] = \"{EXPECTED_AMBOSO_API_LEVEL}\"; /**< Represents amboso version used for [anvil__{bin_name}.h] generated header.*/\n
 static const char ANVIL__{bin_name}__VERSION_STRING[] = \"{target_tag}\"; /**< Represents current version for [anvil__{bin_name}.h] generated header.*/\n
 static const char ANVIL__{bin_name}__VERSION_DESC[] = \"{id}\"; /**< Represents current version info for [anvil__{bin_name}.h] generated header.*/\n
 static const char ANVIL__{bin_name}__VERSION_DATE[] = \"{commit_time}\"; /**< Represents date for current version for [anvil__{bin_name}.h] generated header.*/\n

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -89,7 +89,7 @@ pub fn do_build(env: &AmbosoEnv, args: &Args) -> Result<String,String> {
                             } else {
                                 let output = Command::new("sh")
                                     .arg("-c")
-                                    .arg(format!("aclocal ; autoconf ; automake --add-missing ; ./configure"))
+                                    .arg(format!("aclocal ; autoconf ; automake --add-missing ; ./configure \"{}\"", env.configure_arg))
                                     .output()
                                     .expect("failed to execute process");
 


### PR DESCRIPTION
- Add commit info to C header
- Add `EXPECTED_AMBOSO_API_LEVEL`
- Add `--no-color` arg to turn off color output
- Fix generated C header being stuck with "helapordo"
- Closes #59 