### PR TITLE
feat: functionality for -s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- C header gen was missing some underscores
+
 ## [0.1.4] - 2023-12-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.5] - 2023-12-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Functionality for -s flag
 
+- Lint only functionality for -x when -l is provided
+
 ### Fixed
 
 - C header gen was missing some underscores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Functionality for -s flag
+
 ### Fixed
 
 - C header gen was missing some underscores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.1.5-dev"
+version = "0.1.5"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.1.4"
+version = "0.1.5-dev"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.1.4"
+version = "0.1.5-dev"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.1.5-dev"
+version = "0.1.5"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -13,10 +13,25 @@
 
 ## What is this thing? <a name = "witt"></a>
 
-  This is a Rust implementation of [amboso](https://github.com/jgabaut/amboso), a basic build tool wrapping make and supporting git tags.
+  This is a Rust port of [amboso](https://github.com/jgabaut/amboso), a basic build tool wrapping make and supporting git tags.
 
-  It's almost on par with the original implementation, as of amboso 1.9.7.
-  Check the next section for support info.
+  It's almost on par with the original implementation, as of `amboso` `1.9.9`.
+  Check the [next section](#supported_amboso) for more support info.
+
+  Invil can be used to:
+  - Automate building a repo-curated list of git tagged versions (or also basic tagged versions with a full directory copy).
+    - Ideally, the build command should be as short as `invil build`.
+  - Run tests for a repo-curated directory with output comparison.
+  - Generate new projects supporting the build tool using `invil init <DIR>`
+
+  At the moment, only C projects are supported.
+  Different build modes are provided internally, depending on how full your autotool build support is:
+  - Basic mode: a single `gcc` call. This may be expanded in a future version, to at least provide support for passing arguments to the compiler.
+  - Make mode: for all tags higher than the version specified as providing make support, `invil` will expect a ready `Makefile` that correctly builds the target binary when `make` is called.
+  - Automake mode: for all tags higher than the version specified as providing automake support, `invil` will expect a `Makefile.am` and a `configure.ac`, so that a `Makefile` with the same assumptions as Make mode can be generated.
+
+  For more information on the `stego.lock` file, see the [amboso info](https://github.com/jgabaut/amboso#stego) about it. Better documentation should come.
+
 
 ## Supported amboso features <a name = "supported_amboso"></a>
 
@@ -100,11 +115,9 @@ Check out [this page](https://github.com/jgabaut/invil/blob/master/bench/gitmode
 
 ## Todo <a name = "todo"></a>
 
-  - Implement silent functionality
   - Extend original impl by handling autotools in base mode
   - Improve logging with a custom format
   - Improve horrendous git mode command chain
     - The current implementation is naive and just calls a bunch of `Command` to pipeline the git operations in a ugly iper-indented mess.
     - Resorting to shell commands is bad and defeats the purpose of this rewrite.
     - We have git2 crate to handle the git commands and should be able to reduce the amount of command wrapping.
-  - Add detailed git info for C header generation

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
   - [x] Watch flag: `-w`
   - [x] Warranty flag: `-W`
   - [x] Ignore gitcheck flag: `-X`
-  - [ ] Silent: `-s`
+  - [x] Silent: `-s`
   - [x] Pass config argument: `-C`
 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
   - [x] Basic env flags:  `-D`, `-K`, `-M`, `-S`, `-E`
   - [ ] Clock flag: `-Y <startTime>`
   - [x] Linter mode: `-x`
-    - [ ] Lint only: `-l`
+    - [x] Lint only: `-l`
     - [ ] Report lex: `-L`
   - [x] C header gen mode: `-G` (detailed info is empty)
   - [x] Verbose flag: `-V`

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
     - Handle test macro flag to run on all valid queries
     - Record test output with `-b`
       - Not compliant with amboso <1.9.7 expectations: missing trailing `$`.
-  - Passing configure arguments: (\*)
-    - Amboso 1.9.8 expects -C flag to be passing the arguments directly, not by reading a file.
+  - Passing configure arguments: complete support
+    - Not compliament with amboso <1.9.9 expectations: -C flag was passing the arguments directly, not by reading a file.
   - Subcommands:
     - build    Quickly build latest version for current mode
     - init     Prepare new project with amboso
@@ -70,7 +70,7 @@
   - [x] Warranty flag: `-W`
   - [x] Ignore gitcheck flag: `-X`
   - [ ] Silent: `-s`
-  - [ ] Pass config argument: `-C` (See above)
+  - [x] Pass config argument: `-C`
 
 
 ## Extensions

--- a/src/core.rs
+++ b/src/core.rs
@@ -40,7 +40,7 @@ pub const ANVIL_AUTOMAKE_VERS_KEYNAME: &str = "automakevers";
 pub const ANVIL_TESTSDIR_KEYNAME: &str = "tests";
 pub const ANVIL_BONEDIR_KEYNAME: &str = "testsdir";
 pub const ANVIL_KULPODIR_KEYNAME: &str = "errortestsdir";
-pub const EXPECTED_AMBOSO_API_LEVEL: &str = "1.9.7";
+pub const EXPECTED_AMBOSO_API_LEVEL: &str = "1.9.9";
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about = format!("{} - A simple build tool leveraging make", INVIL_NAME), long_about = format!("{} - A drop-in replacement for amboso", INVIL_NAME), disable_version_flag = true)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -25,7 +25,9 @@ use is_executable::is_executable;
 use toml::Table;
 use std::process::ExitCode;
 use std::io::Write;
-use crate::utils::print_grouped_args;
+use crate::utils::{
+    print_grouped_args,
+};
 
 pub const INVIL_NAME: &str = env!("CARGO_PKG_NAME");
 pub const INVIL_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -171,6 +173,12 @@ pub enum AmbosoMode {
     TestMacro,
     GitMode,
     BaseMode,
+}
+
+#[derive(Debug)]
+pub enum AmbosoLintMode {
+    FullCheck,
+    LintOnly,
 }
 
 #[derive(Debug)]
@@ -1180,32 +1188,6 @@ pub fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
             }
         }
         None => {}
-    }
-
-    match args.linter {
-        Some(ref x) => {
-            info!("Linter for file: {{{}}}", x.display());
-            if x.exists() {
-                trace!("Found {}", x.display());
-                let res = parse_stego_toml(x);
-                match res {
-                    Ok(_) => {
-                        info!("Lint successful for {{{}}}.", x.display());
-                        return Ok(anvil_env);
-                    }
-                    Err(e) => {
-                        error!("Failed lint for {{{}}}.\nError was:    {e}",x.display());
-                        return Err(e);
-                    }
-                }
-            } else {
-                error!("Could not find file: {{{}}}", x.display());
-                return Err("Failed linter call".to_string());
-            }
-        }
-        None => {
-            trace!("-x not asserted.");
-        }
     }
 
     //Default mode is git

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,25 +53,33 @@ fn main() -> ExitCode {
         args.verbose -= 1;
     }
 
-    match args.verbose {
-        5 => {
-            log_level = LevelFilter::Trace;
-        },
-        4 => {
-            log_level = LevelFilter::Debug;
-        },
-        3 => {
-            log_level = LevelFilter::Info;
-        },
-        2 => {
-            log_level = LevelFilter::Warn;
-        },
-        1|0 => {
+    match args.silent {
+        true => {
             log_level = LevelFilter::Error;
-        },
-        _ => {
-            log_level = LevelFilter::Debug;
-        },
+        }
+        false => {
+            match args.verbose {
+                5 => {
+                    log_level = LevelFilter::Trace;
+                },
+                4 => {
+                    log_level = LevelFilter::Debug;
+                },
+                3 => {
+                    log_level = LevelFilter::Info;
+                },
+                2 => {
+                    log_level = LevelFilter::Warn;
+                },
+                1|0 => {
+                    log_level = LevelFilter::Error;
+                },
+                _ => {
+                    log_level = LevelFilter::Debug;
+                },
+            }
+
+        }
     }
 
     let config = ConfigBuilder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,13 @@ use crate::core::{Args, Commands,
     check_passed_args,
     handle_amboso_env,
     handle_init_subcommand,
+    AmbosoLintMode
 };
 use crate::utils::{
     print_warranty_info,
     prog_name,
 };
+use crate::ops::handle_linter_flag;
 use clap::Parser;
 
 fn main() -> ExitCode {
@@ -144,6 +146,34 @@ fn main() -> ExitCode {
             return ExitCode::SUCCESS;
         }
         _ => {} //Other subcommands may be handled later, in handle_amboso_env()
+    }
+
+    match args.linter {
+        Some(ref x) => {
+            let lint_mode;
+            match args.list {
+                true => {
+                    lint_mode = AmbosoLintMode::LintOnly;
+                }
+                false => {
+                    lint_mode = AmbosoLintMode::FullCheck;
+                }
+            }
+            let res = handle_linter_flag(x, lint_mode);
+            match res {
+                Ok(s) => {
+                    info!("{s}");
+                    return ExitCode::SUCCESS;
+                }
+                Err(e) => {
+                    error!("handle_linter_flag() failed. Err: {e}");
+                    return ExitCode::FAILURE;
+                }
+            }
+        }
+        None => {
+            trace!("-x not asserted.");
+        }
     }
 
     let res_check = check_passed_args(&mut args);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -879,8 +879,8 @@ static const char ANVIL__{bin_name}__VERSION_AUTHOR[] = \"{head_author_name}\"; 
 const char *get_ANVIL__API__LEVEL__(void); /**< Returns a version string for amboso API of [anvil__{bin_name}.h] generated header.*/\n
 const char *get_ANVIL__VERSION__(void); /**< Returns a version string for [anvil__{bin_name}.h] generated header.*/\n
 const char *get_ANVIL__VERSION__DESC__(void); /**< Returns a version info string for [anvil__{bin_name}.h] generated header.*/\n
-const char *get_ANVIL__VERSION__DATE(void); /**< Returns a version date string for [anvil__{bin_name}.h] generated header.*/\n
-const char *get_ANVIL__VERSION__AUTHOR(void); /**< Returns a version author string for [anvil__{bin_name}.h] generated header.*/\n
+const char *get_ANVIL__VERSION__DATE__(void); /**< Returns a version date string for [anvil__{bin_name}.h] generated header.*/\n
+const char *get_ANVIL__VERSION__AUTHOR__(void); /**< Returns a version author string for [anvil__{bin_name}.h] generated header.*/\n
 #ifndef INVIL__{bin_name}__HEADER__
 #define INVIL__{bin_name}__HEADER__
 static const char INVIL__VERSION__STRING[] = \"{INVIL_VERSION}\"; /**< Represents invil version used for [anvil__{bin_name}.h] generated header.*/\n

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -890,7 +890,7 @@ const char *get_INVIL__API__LEVEL__(void); /**< Returns a version string for inv
 const char *get_INVIL__OS__(void); /**< Returns a version string for os used for [anvil__{bin_name}.h] generated header.*/\n
 const char *get_INVIL__COMMIT__DESC__(void); /**< Returns a string for HEAD commit message used for [anvil__{bin_name}.h] generated header.*/\n
 #endif // INVIL__{bin_name}__HEADER__
-#endif");
+#endif\n");
     match output {
         Ok(mut f) => {
             let res = write!(f, "{}", header_string);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,8 +13,10 @@
  */
 use crate::core::{Args, Commands};
 use std::{env};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::ffi::OsStr;
+use std::fs;
+use toml::Table;
 
 pub fn prog_name() -> Option<String> {
     env::current_exe().ok()
@@ -211,4 +213,20 @@ pub fn print_warranty_info() {
   PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
   IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
   ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n");
+}
+
+pub fn try_parse_stego(stego_path: &PathBuf) -> Result<String,String> {
+    let stego = fs::read_to_string(stego_path).expect("Could not read {stego_path} contents");
+    trace!("Stego contents: {{{}}}", stego);
+    let toml_value = stego.parse::<Table>();
+    match toml_value {
+        Ok(_) => {
+            debug!("try_parse_stego(): Lint success for {{{}}}", stego_path.display());
+            return Ok("Lint success".to_string());
+        }
+        Err(e) => {
+            error!("Lint failed for {{{}}}. Err: {e}", stego_path.display());
+            return Err("Lint failed".to_string());
+        }
+    }
 }


### PR DESCRIPTION
- fix: missing underscores in C header
- fix: add trailing newline to C header
- feat: silent functionality for -s
- feat: lint only with -lx
- chore: bump version to `0.1.5`
- chore: bump `EXPECTED_AMBOSO_API_LEVEL` to `1.9.9`