### PR TITLE
feat: expect amboso 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ hello_world
 #ignore .o files
 *.o
 
+#ignore anvil.log
+anvil.log
 #ignore invil.log
 invil.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.0] - 2023-12-26
 
 ### Added
 
 - New short versions of extensions, compatible with amboso 2.0
 - Tests for is_semver()
+- Read CFLAGS from env for do_build()
 
 ### Changed
 
 - Test failure returns 1
 - is_semver() rejects build and prerelease metadata
+- Log file is now anvil.log
+- Expected amboso version bumped to 2.0.0
 
 ## [0.1.7] - 2023-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New short versions of extensions, compatible with amboso 2.0
 - Tests for is_semver()
 - Read CFLAGS from env for do_build()
+- Try doing make when no args are provided
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New short versions of extensions, compatible with amboso 2.0
 - Tests for is_semver()
 - Read CFLAGS from env for do_build()
+- Read CC from env for do_build() when below ANVIL_MAKEVERS
 - Try doing make when no args are provided
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Tests for is_semver()
+
 ### Changed
 
 - Test failure returns 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Test failure returns 1
+
 ## [0.1.7] - 2023-12-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- New short versions of extensions, compatible with amboso 2.0
 - Tests for is_semver()
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Test failure returns 1
+- is_semver() rejects build and prerelease metadata
 
 ## [0.1.7] - 2023-12-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.1.8-dev"
+version = "0.2.0"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.1.7"
+version = "0.1.8-dev"
 dependencies = [
  "clap",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.1.8-dev"
+version = "0.2.0"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.1.7"
+version = "0.1.8-dev"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@
     - Record test output with `-b`
       - Not compliant with amboso <1.9.7 expectations: missing trailing `$`.
   - Passing configure arguments: complete support
-    - Not compliament with amboso <1.9.9 expectations: -C flag was passing the arguments directly, not by reading a file.
+    - Not compliant with amboso <1.9.9 expectations: -C flag was passing the arguments directly, not by reading a file.
   - Subcommands:
     - build    Quickly build latest version for current mode
     - init     Prepare new project with amboso
     - version  Print invil version
 
   - Note:
-    - As of version `0.1.6`, by default `make rebuild` is called on build operation. To revert to original behaviour and call just `make`, run with `--no-rebuild`.
+    - As of version `0.1.6`, by default `make rebuild` is called on build operation. This is the expected behaviour of `amboso` `2.x`. To revert to `1.x` original behaviour and call just `make`, run with `--no-rebuild`.
 
   Flags support status:
 
@@ -90,9 +90,15 @@
   - [x] Silent: `-s`
   - [x] Pass config argument: `-C`
   - [ ] Run make pack: `-z`
+  - [x] No rebuild: `-R`
+  - [x] Logged run: `-J`
+    - Outputs to `./invil.log`. Not backwards compatible with repos not ignoring the file explicitly.
+  - [x] No color: `-P`
+  - [x] Force build: `-F`
+  - [ ] Run make when no arguments are provided
 
 
-## Extensions
+## Extensions, relative to amboso 1.9.9
 
   - [x] When in `make` build mode, call `make rebuild` by default
     - [x] `--no-rebuild` to disable make rebuild and run just `make`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
   This is a Rust port of [amboso](https://github.com/jgabaut/amboso), a basic build tool wrapping make and supporting git tags.
 
-  It's almost on par with the original implementation, as of `amboso` `1.9.9`.
+  It's (\*) on par with the original implementation, as of `amboso` `2.0.0`.
   Check the [next section](#supported_amboso) for more support info.
 
   Invil can be used to:
@@ -92,7 +92,7 @@
   - [ ] Run make pack: `-z`
   - [x] No rebuild: `-R`
   - [x] Logged run: `-J`
-    - Outputs to `./invil.log`. Not backwards compatible with repos not ignoring the file explicitly.
+    - Outputs to `./anvil.log`. Not backwards compatible with repos not ignoring the file explicitly.
   - [x] No color: `-P`
   - [x] Force build: `-F`
   - [ ] Run make when no arguments are provided

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
     - Outputs to `./anvil.log`. Not backwards compatible with repos not ignoring the file explicitly.
   - [x] No color: `-P`
   - [x] Force build: `-F`
-  - [ ] Run make when no arguments are provided
+  - [x] Run make when no arguments are provided
 
 
 ## Extensions, relative to amboso 1.9.9

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -13,8 +13,8 @@ errortestsdir = "kulpo"
 
 [versions]
 
-"-0.0.5" = "First release supporting base mode build. gcc call only"
-"-0.0.7" = "First release supporting base mode build. Wrap make"
+"B0.0.5" = "First release supporting base mode build. gcc call only"
+"B0.0.7" = "First release supporting base mode build. Wrap make"
 "0.0.8" = "First tag available in git mode."
 "0.0.9" = "First tag supporting C header gen."
 "0.1.0" = "First tag supporting test mode."

--- a/src/core.rs
+++ b/src/core.rs
@@ -1513,7 +1513,7 @@ fn is_semver(input: &str) -> bool {
         r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
     )
     .expect("Failed to create regex");
-    let strict_regex = Regex::new(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$").unwrap();
+    let strict_regex = Regex::new(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$").expect("Failed to create regex");
 
     if strict_regex.is_match(input) {
         return true;

--- a/src/core.rs
+++ b/src/core.rs
@@ -455,7 +455,8 @@ pub fn handle_amboso_env(env: &mut AmbosoEnv, args: &mut Args) {
                     trace!("{}", s);
                 }
                 Err(e) => {
-                    warn!("do_query() failed in handle_amboso_env(). Err: {}", e);
+                    error!("do_query() failed in handle_amboso_env(). Err: {}", e);
+                    exit(1);
                 }
             }
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -151,19 +151,19 @@ pub struct Args {
     pub ignore_gitcheck: bool,
 
     /// Output to log file
-    #[arg(long, default_value = "false")]
+    #[arg(short = 'J', long, default_value = "false")]
     pub logged: bool,
 
     /// Disable color output
-    #[arg(long, default_value = "false")]
+    #[arg(short = 'P', long, default_value = "false")]
     pub no_color: bool,
 
     /// Enable force build
-    #[arg(long, default_value = "false")]
+    #[arg(short = 'F', long, default_value = "false")]
     pub force: bool,
 
     /// Disable calling make rebuild
-    #[arg(long, default_value = "false")]
+    #[arg(short = 'R', long, default_value = "false")]
     pub no_rebuild: bool,
 
     /// Pass configuration argument
@@ -534,6 +534,7 @@ fn handle_subcommand(args: &mut Args, env: &mut AmbosoEnv) {
                 }
             }
         }
+        //TODO: be make when no args are supplied
         _ => {}
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -534,7 +534,6 @@ fn handle_subcommand(args: &mut Args, env: &mut AmbosoEnv) {
                 }
             }
         }
-        //TODO: be make when no args are supplied
         _ => {}
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -34,7 +34,7 @@ use std::fmt;
 pub const INVIL_NAME: &str = env!("CARGO_PKG_NAME");
 pub const INVIL_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const INVIL_OS: &str = env::consts::OS;
-pub const INVIL_LOG_FILE: &str = "invil.log";
+pub const INVIL_LOG_FILE: &str = "anvil.log";
 pub const ANVIL_SOURCE_KEYNAME: &str = "source";
 pub const ANVIL_BIN_KEYNAME: &str = "bin";
 pub const ANVIL_MAKE_VERS_KEYNAME: &str = "makevers";
@@ -42,7 +42,7 @@ pub const ANVIL_AUTOMAKE_VERS_KEYNAME: &str = "automakevers";
 pub const ANVIL_TESTSDIR_KEYNAME: &str = "tests";
 pub const ANVIL_BONEDIR_KEYNAME: &str = "testsdir";
 pub const ANVIL_KULPODIR_KEYNAME: &str = "errortestsdir";
-pub const EXPECTED_AMBOSO_API_LEVEL: &str = "1.9.9";
+pub const EXPECTED_AMBOSO_API_LEVEL: &str = "2.0.0";
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about = format!("{} - A simple build tool leveraging make", INVIL_NAME), long_about = format!("{} - A drop-in replacement for amboso", INVIL_NAME), disable_version_flag = true)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -869,8 +869,8 @@ pub fn parse_stego_toml(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
                     warn!("versions_table is empty.");
                 } else {
                     for (key, value) in anvil_env.versions_table.iter() {
-                        if key.to_string().starts_with('-') {
-                            let trimmed_key = key.to_string().trim_start_matches('-').to_string();
+                        if key.to_string().starts_with('B') {
+                            let trimmed_key = key.to_string().trim_start_matches('B').to_string();
                             if ! is_semver(&trimmed_key) {
                                 error!("Invalid semver key: {{{}}}", trimmed_key);
                                 return Err("Invalid semver key".to_string());
@@ -1673,8 +1673,8 @@ pub fn lex_stego_toml(stego_path: &PathBuf) -> Result<String,String> {
                     warn!("versions_table is empty.");
                 } else {
                     for (key, value) in versions_table.iter() {
-                        if key.to_string().starts_with('-') {
-                            let trimmed_key = key.to_string().trim_start_matches('-').to_string();
+                        if key.to_string().starts_with('B') {
+                            let trimmed_key = key.to_string().trim_start_matches('B').to_string();
                             if ! is_semver(&trimmed_key) {
                                 error!("Invalid semver key: {{{}}}", trimmed_key);
                                 return Err("Invalid semver key".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,10 @@ use crate::utils::{
     print_warranty_info,
     prog_name,
 };
-use crate::ops::handle_linter_flag;
+use crate::ops::{
+    handle_linter_flag,
+    handle_empty_subcommand,
+};
 use clap::Parser;
 
 fn main() -> ExitCode {
@@ -144,6 +147,9 @@ fn main() -> ExitCode {
         Some(Commands::Version) => {
             println!("{INVIL_VERSION}\n");
             return ExitCode::SUCCESS;
+        }
+        None => {
+           handle_empty_subcommand();
         }
         _ => {} //Other subcommands may be handled later, in handle_amboso_env()
     }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -981,7 +981,7 @@ const char *get_INVIL__OS__(void)
 {{
     return INVIL__OS__STRING;
 }}
-#endif");
+#endif\n");
     match output {
         Ok(mut f) => {
             let res = write!(f, "{}", c_impl_string);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -155,6 +155,18 @@ pub fn do_build(env: &AmbosoEnv, args: &Args) -> Result<String,String> {
                                     cflg_str = "".to_string();
                                 }
                             }
+                            let cc = "CC";
+                            let cc_str;
+                            match env::var(cc) {
+                                Ok(val) => {
+                                    debug!("Using {{{}: {}}}", cc, val);
+                                    cc_str = format!("{}",val);
+                                },
+                                Err(e) => {
+                                    error!("Failed reading {{{}: {}}}", cc, e);
+                                    cc_str = "gcc".to_string();
+                                }
+                            }
                             if use_make {
                                 trace!("Using make mode");
                                 Command::new("sh")
@@ -165,7 +177,7 @@ pub fn do_build(env: &AmbosoEnv, args: &Args) -> Result<String,String> {
                             } else {
                                 Command::new("sh")
                                     .arg("-c")
-                                    .arg(format!("{} gcc {} -o {} -lm", cflg_str, source_path.display(), bin_path.display()))
+                                    .arg(format!("{} {} {} -o {} -lm", cflg_str, cc_str, source_path.display(), bin_path.display()))
                                     .output()
                                     .expect("failed to execute process")
                             }


### PR DESCRIPTION
- do_query() errors call `exit(1)`
- `is_semver()` rejects metadata
- Use `B` prefix for base tags
- Add new short flags for extensions to `amboso` `<2.0.0`
- Add `handle_empty_subcommand()`
- Read `CFLAGS` from env
- Read `CC` from env