### PR TITLE
feat: 0.2.13 Fix broken test recording for stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.13] - 2024-04-27
+
+### Fixed
+
+- Test mode actually records test when -b is passed
+
 ## [0.2.12] - 2024-04-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.2.13-dev"
+version = "0.2.13"
 dependencies = [
  "clap",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.2.12"
+version = "0.2.13-dev"
 dependencies = [
  "clap",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.2.12"
+version = "0.2.13-dev"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.2.13-dev"
+version = "0.2.13"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -790,16 +790,30 @@ pub fn run_test(test_path: &PathBuf, record: bool) -> Result<String,String> {
                         if matching == stderr_record.as_bytes().len() && matching == output.stderr.len() {
                             info!("Stderr matched!");
                         } else {
-                            warn!("Stderr did not match!");
-                            warn!("Expected: {{\"\n{}\"}}", stderr_record);
-                            match std::str::from_utf8(&output.stderr) {
-                                Ok(v) => {
-                                    info!("Found: {{\"\n{}\"}}", v);
-                                    return Err("Stderr mismatch".to_string());
+                            if record {
+                                info!("Recording stderr");
+                                let write_res = fs::write(stderr_record_path,output.stderr);
+                                match write_res {
+                                    Ok(_) => {
+                                        debug!("Recorded stderr");
+                                    }
+                                    Err(e) => {
+                                        error!("Failed recording stderr. Err: {e}");
+                                        return Err("Failed recording stderr".to_string());
+                                    }
                                 }
-                                Err(e) => {
-                                    error!("Failed parsing output.stderr. Err: {e}");
-                                    return Err("Failed parsing output.stderr".to_string());
+                            } else {
+                                warn!("Stderr did not match!");
+                                warn!("Expected: {{\"\n{}\"}}", stderr_record);
+                                match std::str::from_utf8(&output.stderr) {
+                                    Ok(v) => {
+                                        info!("Found: {{\"\n{}\"}}", v);
+                                        return Err("Stderr mismatch".to_string());
+                                    }
+                                    Err(e) => {
+                                        error!("Failed parsing output.stderr. Err: {e}");
+                                        return Err("Failed parsing output.stderr".to_string());
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
- This fix should ensure `run_test()` actually records stderr when requested (with `-b`).
- Closes #132 
- Bump version to `0.2.13`