### PR TITLE
feat: 0.2.17 Fix C header gen, add config file reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.2.17] - 2024-08-29
+
+### Added
+
+- Read global config file from $HOME/.anvil/anvil.toml
+
+### Changed
+
+- Fix C header generation not using passed tag's info
+- Bump expected amboso version to 2.0.7
+
+## [0.2.16] - 2024-08-10
+
+### Changed
+
+- Print warranty info after version splash
+- Bump deps
+
 ## [0.2.15] - 2024-07-03
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.2.17-dev"
+version = "0.2.17"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -95,9 +95,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.14"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c937d4061031a6d0c8da4b9a4f98a172fc2976dfb1c19213a9cf7d0d3c837e36"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.14"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85379ba512b21a328adf887e85f7742d12e96eb31f3ef077df4ffc26b506ffed"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -158,6 +158,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -202,6 +223,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -253,9 +285,10 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.2.16"
+version = "0.2.17-dev"
 dependencies = [
  "clap",
+ "dirs",
  "flate2",
  "git2",
  "is_executable",
@@ -312,6 +345,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,11 +400,11 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -396,6 +439,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "percent-encoding"
@@ -440,6 +489,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -559,6 +619,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -686,6 +766,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.2.16"
+version = "0.2.17-dev"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"
@@ -24,8 +24,9 @@ anvilPy = ["dep:flate2", "dep:tar", "dep:url"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.14", features = ["derive"] }
-flate2 = { version = "1.0.31", optional = true }
+clap = { version = "4.5.16", features = ["derive"] }
+dirs = "5.0.1"
+flate2 = { version = "1.0.33", optional = true }
 git2 = "0.19.0"
 is_executable = "1.0.1"
 log = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.2.17-dev"
+version = "0.2.17"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@
   - [x] `-a` to set compatibility level
   - [x] `-k` to set project type
   - [x] `-O` to set stego.lock dir (defaults to working directory)
+  - [x] Retrocompatible `stego.lock` parsing, up to `1.7.x`
+  - [x] Init subcommand uses passed directory's basename for flags
+  - [x] Read global config file from `$HOME/.anvil/anvil.toml`
 
 ## Extended amboso features <a name = "extended_amboso"></a>
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -895,9 +895,9 @@ pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &Strin
                         }
                     }
                 }
-                Err(e) => {
-                    error!("Failed getting {target_tag}");
-                    return Err(e.to_string());
+                Err(_) => {
+                    error!("{}", format!("Failed getting {target_tag}"));
+                    return Err(format!("Failed getting tag {{{target_tag}}}"));
                 }
             }
         }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -857,41 +857,47 @@ pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &Strin
     }
     match repo {
         Ok(r) => {
-            let head = r.head();
-            match head {
-                Ok(head) => {
-                    let commit = head.peel_to_commit();
-                    match commit {
-                       Ok(commit) => {
-                           if let Some(msg) = commit.message() {
-                               info!("Commit message: {{{}}}", msg);
-                               commit_message = msg.escape_default().to_string();
-                           }
-                           id = commit.id().to_string();
-                           info!("Commit id: {{{}}}", id);
-                           let author = commit.author();
-                           let name = author.name();
-                           match name {
-                              Some(name) => {
-                                   head_author_name = name.to_string();
-                                   info!("Commit author: {{{}}}", head_author_name);
+            let lookup_name = format!("refs/tags/{}", target_tag);
+            let reference = r.find_reference(&lookup_name);
+            match reference {
+                Ok(refr) => {
+                    if !refr.is_tag() {
+                        error!("{target_tag} is not a reference");
+                        return Err("ERROR".to_string());
+                    } else {
+                        let commit = refr.peel_to_commit();
+                        match commit {
+                            Ok(commit) => {
+                               if let Some(msg) = commit.message() {
+                                   info!("Commit message: {{{}}}", msg);
+                                   commit_message = msg.escape_default().to_string();
                                }
-                               None => {
-                                   warn!("Commit author is empty: {}", head_author_name);
-                               }
+                               id = commit.id().to_string();
+                               info!("Commit id: {{{}}}", id);
+                               let author = commit.author();
+                               let name = author.name();
+                               match name {
+                                  Some(name) => {
+                                       head_author_name = name.to_string();
+                                       info!("Commit author: {{{}}}", head_author_name);
+                                   }
+                                   None => {
+                                       warn!("Commit author is empty: {}", head_author_name);
+                                   }
+                                }
+                                commit_time = commit.time().seconds();
+                                info!("Commit time: {{{}}}", commit_time);
+                                   }
+                            Err(e) => {
+                                       error!("Failed peel to head commit for {{{}}}. Err: {e}", target_path.display());
+                                       return Err("Failed peel to head commit for repo".to_string());
                             }
-                            commit_time = commit.time().seconds();
-                            info!("Commit time: {{{}}}", commit_time);
-                               }
-                               Err(e) => {
-                                   error!("Failed peel to head commit for {{{}}}. Err: {e}", target_path.display());
-                                   return Err("Failed peel to head commit for repo".to_string());
-                               }
-                            }
+                        }
+                    }
                 }
                 Err(e) => {
-                    error!("Failed getting head for {{{}}}. Err: {e}", target_path.display());
-                    return Err("Failed getting head for repo".to_string());
+                    error!("Failed getting {target_tag}");
+                    return Err(e.to_string());
                 }
             }
         }


### PR DESCRIPTION
### Added

- Read config file from `$HOME/.anvil/anvil.toml`
  - Closes #169 

### Changed

- Fix C header generation not using passed tag's info
  - Closes #173 
- Bump `EXPECTED_AMBOSO_API_LEVEL` to `2.0.7`
- Bump deps