### PR TITLE
feat: 0.2.18 Improved -x flag, fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.18] - 2024-10-24
+
+### Changed
+
+- Fix: avoid error on relative paths with no `./` for `-x`, `-Lx`
+- Fix: don't try parsing global conf when file doesn't exist
+- Bump `EXPECTED_AMBOSO_API_LEVEL` to `2.0.8`
+
 ## [0.2.17] - 2024-08-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.2.18-dev"
+version = "0.2.18"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.2.17"
+version = "0.2.18-dev"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "is_executable"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+checksum = "4ba3d8548b8b04dafdf2f4cc6f5e379db766d0a6d9aac233ad4c9a92ea892233"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ anvilPy = ["dep:flate2", "dep:tar", "dep:url"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.17", features = ["derive"] }
+clap = { version = "4.5.18", features = ["derive"] }
 dirs = "5.0.1"
 flate2 = { version = "1.0.33", optional = true }
 git2 = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.2.18-dev"
+version = "0.2.18"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ clap = { version = "4.5.17", features = ["derive"] }
 dirs = "5.0.1"
 flate2 = { version = "1.0.33", optional = true }
 git2 = "0.19.0"
-is_executable = "1.0.1"
+is_executable = "1.0.3"
 log = "0.4.22"
 regex = "1.10.6"
 simplelog = "0.12.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.2.17"
+version = "0.2.18-dev"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"
@@ -24,7 +24,7 @@ anvilPy = ["dep:flate2", "dep:tar", "dep:url"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.16", features = ["derive"] }
+clap = { version = "4.5.17", features = ["derive"] }
 dirs = "5.0.1"
 flate2 = { version = "1.0.33", optional = true }
 git2 = "0.19.0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   - Generate new projects supporting the build tool using `invil init <DIR>`
   - Generate a basic header+impl containing project info, such as time of current commit
 
-  It's (\*) on par with the original implementation, as of `amboso` `2.0.6`.
+  It's (\*) on par with the original implementation, as of `amboso` `2.0.8`.
   Check the [next section](#supported_amboso) for more support info.
   Check [this section](#extended_amboso) for info about extensions to `amboso 2.0.4`.
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -2267,7 +2267,28 @@ pub fn lex_stego_toml(stego_path: &PathBuf) -> Result<String,String> {
                 if let Some(table) = y.get(t.0).and_then(|v| v.as_table()) {
                     for key in table.keys() {
                         if let Some(val) = table.get(key) {
-                            println!("Variable: {}_{}, Value: {}", t.0, key, val);
+                            if val.is_str() {
+                                println!("Variable: {}_{}, Value: {}", t.0, key, val);
+                            } else if val.is_array() {
+                                println!("Array: {}_{}, Name: {}", t.0, key, key);
+                                for (i, inner_v) in val.as_array().expect("Failed parsing array").iter().enumerate() {
+                                    if inner_v.is_str() {
+                                        println!("Arrvalue: {}_{}[{}], Value: {}", t.0, key, i, inner_v);
+                                    }
+                                }
+                            } else if val.is_table() {
+                                println!("Struct: {}_{}, Name: {}", t.0, key, key);
+                                let tab = val.as_table().expect("Failed parsing table");
+                                for inner_k in tab.keys() {
+                                    if let Some(inner_v) = tab.get(inner_k) {
+                                        if inner_v.is_str() {
+                                            println!("Structvalue: {}_{}_{}, Value: {}", t.0, key, inner_k, inner_v);
+                                        }
+                                    } else {
+                                        error!("Could not parse inner key {inner_k} for table {key}")
+                                    }
+                                }
+                            }
                         } else {
                             error!("Could not parse {key}");
                         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1085,10 +1085,13 @@ pub fn parse_stego_toml(stego_path: &PathBuf, builds_path: &PathBuf) -> Result<A
     let start_time = Instant::now();
     let stego = fs::read_to_string(stego_path).expect("Could not read {stego_path} contents");
     //trace!("Stego contents: {{{}}}", stego);
-    let mut stego_dir = stego_path.clone().canonicalize().expect("Could not canonicalize {stego_path} contents");
+    let mut stego_dir = stego_path.clone();
     if ! stego_dir.pop() {
         error!("Failed pop for {{{}}}", stego_dir.display());
         return Err(format!("Unexpected stego_dir value: {{{}}}", stego_dir.display()));
+    }
+    if stego_dir.to_str().expect("Could not stringify {stego_path}") == "" {
+        stego_dir = PathBuf::from(".");
     }
     if stego_dir.exists() {
         trace!("Setting ANVIL_STEGODIR to {{{}}}", stego_dir.display());
@@ -2256,10 +2259,13 @@ pub fn lex_stego_toml(stego_path: &PathBuf) -> Result<String,String> {
     let stego = fs::read_to_string(stego_path).expect("Could not read {stego_path} contents");
     trace!("Stego contents: {{{}}}", stego);
     let toml_value = stego.parse::<Table>();
-    let mut stego_dir = stego_path.clone().canonicalize().expect("Could not canonicalize {stego_path} contents");
+    let mut stego_dir = stego_path.clone();
     if ! stego_dir.pop() {
         error!("Failed pop for {{{}}}", stego_dir.display());
         return Err("Unexpected stego_dir value: {{{stego_dir.display()}}}".to_string());
+    }
+    if stego_dir.to_str().expect("Could not stringify {stego_path}") == "" {
+        stego_dir = PathBuf::from(".");
     }
     if stego_dir.exists() {
         info!("ANVIL_BINDIR = {{{}}}", stego_dir.display());

--- a/src/core.rs
+++ b/src/core.rs
@@ -1085,7 +1085,7 @@ pub fn parse_stego_toml(stego_path: &PathBuf, builds_path: &PathBuf) -> Result<A
     let start_time = Instant::now();
     let stego = fs::read_to_string(stego_path).expect("Could not read {stego_path} contents");
     //trace!("Stego contents: {{{}}}", stego);
-    let mut stego_dir = stego_path.clone();
+    let mut stego_dir = stego_path.clone().canonicalize().expect("Could not canonicalize {stego_path} contents");
     if ! stego_dir.pop() {
         error!("Failed pop for {{{}}}", stego_dir.display());
         return Err(format!("Unexpected stego_dir value: {{{}}}", stego_dir.display()));

--- a/src/core.rs
+++ b/src/core.rs
@@ -2256,7 +2256,7 @@ pub fn lex_stego_toml(stego_path: &PathBuf) -> Result<String,String> {
     let stego = fs::read_to_string(stego_path).expect("Could not read {stego_path} contents");
     trace!("Stego contents: {{{}}}", stego);
     let toml_value = stego.parse::<Table>();
-    let mut stego_dir = stego_path.clone();
+    let mut stego_dir = stego_path.clone().canonicalize().expect("Could not canonicalize {stego_path} contents");
     if ! stego_dir.pop() {
         error!("Failed pop for {{{}}}", stego_dir.display());
         return Err("Unexpected stego_dir value: {{{stego_dir.display()}}}".to_string());

--- a/src/core.rs
+++ b/src/core.rs
@@ -48,7 +48,7 @@ pub const ANVIL_BONEDIR_KEYNAME: &str = "testsdir";
 pub const ANVIL_KULPODIR_KEYNAME: &str = "errortestsdir";
 pub const ANVIL_VERSION_KEYNAME: &str = "version";
 pub const ANVIL_KERN_KEYNAME: &str = "kern";
-pub const EXPECTED_AMBOSO_API_LEVEL: &str = "2.0.7";
+pub const EXPECTED_AMBOSO_API_LEVEL: &str = "2.0.8";
 pub const MIN_AMBOSO_V_EXTENSIONS: &str = "2.0.1";
 pub const MIN_AMBOSO_V_STEGO_NOFORCE: &str = "2.0.3";
 pub const MIN_AMBOSO_V_STEGODIR: &str = "2.0.3";
@@ -992,7 +992,7 @@ fn parse_invil_tomlvalue(invil_str: &str, start_time: Instant) -> Result<AmbosoC
                                     info!("Running as <2.0.4");
                                     anvil_conf.anvil_kern = AnvilKern::AmbosoC;
                                 }
-                                "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" => {
+                                "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" => {
                                     info!("Running as {{{}}}", anvil_v_str);
                                     anvil_conf.anvil_kern = AnvilKern::AmbosoC;
                                 }
@@ -1151,7 +1151,7 @@ fn parse_stego_tomlvalue(stego_str: &str, builds_path: &PathBuf, stego_dir: Path
                                     info!("Running as <2.0.4");
                                     anvil_env.anvil_kern = AnvilKern::AmbosoC;
                                 }
-                                "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" => {
+                                "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" => {
                                     info!("Running as {{{}}}", anvil_v_str);
                                     anvil_env.anvil_kern = AnvilKern::AmbosoC;
                                 }
@@ -1736,7 +1736,7 @@ pub fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
                             info!("Running as {}", x.as_str());
                             args.anvil_kern = Some(AnvilKern::AmbosoC.to_string());
                         }
-                        "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" => {
+                        "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" => {
                             info!("Running as {}", x.as_str());
                         }
                         _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ fn main() -> ExitCode {
                             debug!("{s}");
                         }
                         _ => {
-                            info!("{s}");
+                            debug!("{s}");
                         }
                     }
                     return ExitCode::SUCCESS;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1035,7 +1035,7 @@ fn try_lex_makefile(file_path: impl AsRef<Path>, dbg_print: bool, skip_recap: bo
 }
 
 pub fn handle_linter_flag(stego_path: &PathBuf, lint_mode: &AmbosoLintMode) -> Result<String,String> {
-    info!("Linter for file: {{{}}}", stego_path.display());
+    debug!("Linter for file: {{{}}}", stego_path.display());
     if stego_path.exists() {
         trace!("Found {}", stego_path.display());
         match lint_mode {
@@ -1064,8 +1064,21 @@ pub fn handle_linter_flag(stego_path: &PathBuf, lint_mode: &AmbosoLintMode) -> R
             AmbosoLintMode::FullCheck => {
                 let res = parse_stego_toml(stego_path, &PathBuf::from(""));
                 match res {
-                    Ok(_) => {
+                    Ok(r) => {
                         info!("Lint successful for {{{}}}.", stego_path.display());
+                        println!("ANVIL_AUTOMAKE_VERS: {{{}}}", r.mintag_automake.unwrap_or("".to_string()));
+                        println!("ANVIL_MAKE_VERS: {{{}}}", r.mintag_make.unwrap_or("".to_string()));
+                        println!("ANVIL_BIN: {{{}}}", r.bin.unwrap_or("".to_string()));
+                        println!("ANVIL_SOURCE: {{{}}}", r.source.unwrap_or("".to_string()));
+                        println!("ANVIL_TESTDIR: {{{}}}", r.tests_dir.unwrap_or(PathBuf::from("")).display());
+                        println!("ANVIL_BONE_DIR: {{{}}}", r.bonetests_dir.unwrap_or(PathBuf::from("")).display());
+                        println!("ANVIL_KULPO_DIR: {{{}}}", r.kulpotests_dir.unwrap_or(PathBuf::from("")).display());
+                        for bv in r.basemode_versions_table {
+                            println!("ANVIL_BASE_VERSION: {{{}}}", bv.0);
+                        }
+                        for v in r.gitmode_versions_table {
+                            println!("ANVIL_GIT_VERSION: {{{}}}", v.0);
+                        }
                         return Ok("Full linter check success".to_string());
                     }
                     Err(e) => {
@@ -1078,7 +1091,7 @@ pub fn handle_linter_flag(stego_path: &PathBuf, lint_mode: &AmbosoLintMode) -> R
                 let res = lex_stego_toml(stego_path);
                 match res {
                     Ok(_) => {
-                        info!("Lex successful for {{{}}}.", stego_path.display());
+                        debug!("Lex successful for {{{}}}.", stego_path.display());
                         return Ok("Linter lex check success".to_string());
                     }
                     Err(e) => {


### PR DESCRIPTION
### Changed

- Fix: avoid error on relative paths with no `./` for `-x`, `-Lx`
  - Closes #180 
- Fix: don't try parsing global conf when file doesn't exist
  - Closes #181 
- Bump `EXPECTED_AMBOSO_API_LEVEL` to `2.0.8`