### PR TITLE
feat: 0.2.19 Rough support for AnvilCustom, improve anvilPy, use HEAD again when -G receives invalid tag, add -Z, backcomp -C refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 ### Added
 
 - Add -Z to pass CFLAGS to single file build mode
+  - Avoids reading CFLAGS from env
 
 ### Changed
 
 - Fix: avoid error on wrong tag for -G, mimicking amboso
-- Avoid reading CFLAGS from env
 - Try reading AMBOSO_CONFIG_ARG_ISFILE to use -C with flags directly
   - Setting it to 0 enables the new, backwards incompatible behaviour
 - Bump expected amboso version to 2.0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fix: avoid error on wrong tag for -G, mimicking amboso
 - Avoid reading CFLAGS from env
+- Try reading AMBOSO_CONFIG_ARG_ISFILE to use -C with flags directly
+  - Setting it to 0 enables the new, backwards incompatible behaviour
 - Bump expected amboso version to 2.0.9
 
 ## [0.2.18] - 2024-10-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.19] - Unreleased
+
+### Changed
+
+- Fix: avoid error on wrong tag for -G, mimicking amboso
+
 ## [0.2.18] - 2024-10-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## [0.2.19] - Unreleased
 
+### Added
+
+- Add -Z to pass CFLAGS to single file build mode
+
 ### Changed
 
 - Fix: avoid error on wrong tag for -G, mimicking amboso
+- Avoid reading CFLAGS from env
+- Bump expected amboso version to 2.0.9
 
 ## [0.2.18] - 2024-10-24
 
@@ -12,7 +18,7 @@
 
 - Fix: avoid error on relative paths with no `./` for `-x`, `-Lx`
 - Fix: don't try parsing global conf when file doesn't exist
-- Bump `EXPECTED_AMBOSO_API_LEVEL` to `2.0.8`
+- Bump expected amboso version to 2.0.8
 
 ## [0.2.17] - 2024-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changed
 
 - Fix: avoid error on wrong tag for -G, mimicking amboso
-- Fix: improved BaseMode handling by properly doing cd
+- BaseMode cd is now done through env::set_current_dir()
 - Refactored BaseMode do_build() to also use build_step() for queries above anvil_env.makevers
 - Try reading AMBOSO_CONFIG_ARG_ISFILE to use -C with flags directly
   - Setting it to 0 enables the new, backwards incompatible behaviour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Fix: avoid error on wrong tag for -G, mimicking amboso
 - BaseMode cd is now done through env::set_current_dir()
 - Refactored BaseMode do_build() to also use build_step() for queries above anvil_env.makevers
+- Fix: anvilPy does not try to call gcc when query >= makevers
+- Fix: anvilPy does not try to do autotools prep when query >= automakevers
 - Try reading AMBOSO_CONFIG_ARG_ISFILE to use -C with flags directly
   - Setting it to 0 enables the new, backwards incompatible behaviour
 - Bump expected amboso version to 2.0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.19] - Unreleased
+## [0.2.19] - 2024-11-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add -Z to pass CFLAGS to single file build mode
   - Avoids reading CFLAGS from env
+- Basic optional support for AnvilCustom kern
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Changed
 
 - Fix: avoid error on wrong tag for -G, mimicking amboso
+- Fix: improved BaseMode handling by properly doing cd
+- Refactored BaseMode do_build() to also use build_step() for queries above anvil_env.makevers
 - Try reading AMBOSO_CONFIG_ARG_ISFILE to use -C with flags directly
   - Setting it to 0 enables the new, backwards incompatible behaviour
 - Bump expected amboso version to 2.0.9

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "is_executable"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba3d8548b8b04dafdf2f4cc6f5e379db766d0a6d9aac233ad4c9a92ea892233"
+checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
 dependencies = [
  "winapi",
 ]
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.4"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.2.18"
+version = "0.2.19-dev"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
+checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "invil"
-version = "0.2.19-dev"
+version = "0.2.19"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ is_executable = "1.0.4"
 log = "0.4.22"
 regex = "1.11.1"
 simplelog = "0.12.2"
-tar = { version = "0.4.42", optional = true }
+tar = { version = "0.4.43", optional = true }
 toml = "0.8.19"
 url = { version = "2.5.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ anvilCustom = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.20", features = ["derive"] }
+clap = { version = "4.5.21", features = ["derive"] }
 dirs = "5.0.1"
-flate2 = { version = "1.0.34", optional = true }
+flate2 = { version = "1.0.35", optional = true }
 git2 = "0.19.0"
 is_executable = "1.0.4"
 log = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
 [features]
 
 anvilPy = ["dep:flate2", "dep:tar", "dep:url"]
+anvilCustom = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ anvilPy = ["dep:flate2", "dep:tar", "dep:url"]
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
 dirs = "5.0.1"
-flate2 = { version = "1.0.33", optional = true }
+flate2 = { version = "1.0.34", optional = true }
 git2 = "0.19.0"
-is_executable = "1.0.3"
+is_executable = "1.0.4"
 log = "0.4.22"
-regex = "1.10.6"
+regex = "1.11.1"
 simplelog = "0.12.2"
-tar = { version = "0.4.41", optional = true }
+tar = { version = "0.4.42", optional = true }
 toml = "0.8.19"
 url = { version = "2.5.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.2.18"
+version = "0.2.19-dev"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"
@@ -24,7 +24,7 @@ anvilPy = ["dep:flate2", "dep:tar", "dep:url"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.18", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive"] }
 dirs = "5.0.1"
 flate2 = { version = "1.0.33", optional = true }
 git2 = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "invil"
 description = "A port of amboso to Rust"
-version = "0.2.19-dev"
+version = "0.2.19"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/jgabaut/invil"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   - Generate new projects supporting the build tool using `invil init <DIR>`
   - Generate a basic header+impl containing project info, such as time of current commit
 
-  It's (\*) on par with the original implementation, as of `amboso` `2.0.8`.
+  It's (\*) on par with the original implementation, as of `amboso` `2.0.9`.
   Check the [next section](#supported_amboso) for more support info.
   Check [this section](#extended_amboso) for info about extensions to `amboso 2.0.4`.
 
@@ -100,6 +100,7 @@
   - [x] No color: `-P`
   - [x] Force build: `-F`
   - [x] Turn off extensions: `-e` (Only relative to 2.0.0)
+  - [x] Pass CFLAGS to single file build mode: `-Z`
   - [x] Run make when no arguments are provided
 
 
@@ -123,8 +124,9 @@
   - [x] `-k` to set project type
   - [x] `-O` to set stego.lock dir (defaults to working directory)
   - [x] Retrocompatible `stego.lock` parsing, up to `1.7.x`
-  - [x] Init subcommand uses passed directory's basename for flags
+  - [x] Init subcommand uses passed directory's basename for generated flags
   - [x] Read global config file from `$HOME/.anvil/anvil.toml`
+  - [x] `-Z` to pass CFLAGS to single file build mode
 
 ## Extended amboso features <a name = "extended_amboso"></a>
 

--- a/src/anvil_custom.rs
+++ b/src/anvil_custom.rs
@@ -1,0 +1,73 @@
+//  SPDX-License-Identifier: GPL-3.0-only
+/*  Build tool with support for git tags, wrapping make.
+ *  Copyright (C) 2023-2024  jgabaut
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3 of the License.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+use std::path::PathBuf;
+use std::time::Instant;
+use std::fs;
+use toml::Table;
+
+pub const ANVILCUST_CUSTOM_BUILDER_KEYNAME: &str = "custombuilder";
+
+#[derive(Debug)]
+pub struct AnvilCustomEnv {
+    /// Custom builder command string
+    pub custom_builder: String,
+}
+
+pub fn parse_anvilcustom_toml(stego_path: &PathBuf) -> Result<AnvilCustomEnv,String> {
+    let start_time = Instant::now();
+    let stego = fs::read_to_string(stego_path).expect("Could not read {stego_path} contents");
+    //trace!("Pyproject contents: {{{}}}", pyproj);
+    let mut stego_dir = stego_path.clone();
+    if ! stego_dir.pop() {
+        error!("Failed pop for {{{}}}", stego_dir.display());
+        return Err(format!("Unexpected stego_dir value: {{{}}}", stego_dir.display()));
+    }
+    return parse_anvilcustom_tomlvalue(&stego, stego_path, start_time);
+}
+
+fn parse_anvilcustom_tomlvalue(stego_str: &str, stego_path: &PathBuf, start_time: Instant) -> Result<AnvilCustomEnv,String> {
+    let toml_value = stego_str.parse::<Table>();
+    match toml_value {
+        Ok(y) => {
+            let mut anvilcustom_env: AnvilCustomEnv = AnvilCustomEnv {
+                custom_builder : "".to_string(),
+            };
+            trace!("Toml value: {{{}}}", y);
+            if let Some(anvil_table) = y.get("anvil").and_then(|v| v.as_table()) {
+                if let Some(custom_builder) = anvil_table.get(ANVILCUST_CUSTOM_BUILDER_KEYNAME) {
+                    let anvilcust_builder_str = custom_builder.as_str().expect("toml conversion failed");
+                    debug!("anvil_custombuilder: {{{anvilcust_builder_str}}}");
+                    anvilcustom_env.custom_builder = anvilcust_builder_str.to_string();
+                } else {
+                    error!("Missing ANVILCUST_CUSTOM_BUILDER definition.");
+                    return Err(format!("Missing anvil_custombuilder in {{{}}}", stego_path.display()));
+                }
+            } else {
+                error!("Missing anvil section.");
+                return Err(format!("Missing anvil section in {{{}}}", stego_path.display()));
+            }
+
+            let elapsed = start_time.elapsed();
+            debug!("Done parsing pyproject.toml. Elapsed: {:.2?}", elapsed);
+            return Ok(anvilcustom_env);
+        }
+        Err(e) => {
+            let elapsed = start_time.elapsed();
+            debug!("Done parsing stego.toml. Elapsed: {:.2?}", elapsed);
+            error!("Failed parsing {{{}}}  as TOML. Err: [{}]", stego_str, e);
+            return Err("Failed parsing TOML".to_string());
+        }
+    }
+}
+

--- a/src/core.rs
+++ b/src/core.rs
@@ -2004,6 +2004,16 @@ pub fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
                         Ok(anvilpy_env) => {
                             debug!("Done parse_pyproject_toml()");
                             debug!("{:?}", anvilpy_env);
+                            for author in &anvilpy_env.authors {
+                                let mut email = "Unspecified";
+                                if let Some(em) = &author.email {
+                                    email = em;
+                                }
+                                debug!("Author: {{{}}}, Email: {{{}}}", author.name, email);
+                            }
+                            for url in &anvilpy_env.urls {
+                                debug!("{{{}}}: {{{}}}", url.name, url.link);
+                            }
                             anvil_env.anvilpy_env = Some(anvilpy_env);
                         }
                         Err(e) => {

--- a/src/core.rs
+++ b/src/core.rs
@@ -48,7 +48,7 @@ pub const ANVIL_BONEDIR_KEYNAME: &str = "testsdir";
 pub const ANVIL_KULPODIR_KEYNAME: &str = "errortestsdir";
 pub const ANVIL_VERSION_KEYNAME: &str = "version";
 pub const ANVIL_KERN_KEYNAME: &str = "kern";
-pub const EXPECTED_AMBOSO_API_LEVEL: &str = "2.0.8";
+pub const EXPECTED_AMBOSO_API_LEVEL: &str = "2.0.9";
 pub const MIN_AMBOSO_V_EXTENSIONS: &str = "2.0.1";
 pub const MIN_AMBOSO_V_STEGO_NOFORCE: &str = "2.0.3";
 pub const MIN_AMBOSO_V_STEGODIR: &str = "2.0.3";
@@ -1007,7 +1007,7 @@ fn parse_invil_tomlvalue(invil_str: &str, start_time: Instant) -> Result<AmbosoC
                                     info!("Running as <2.0.4");
                                     anvil_conf.anvil_kern = AnvilKern::AmbosoC;
                                 }
-                                "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" => {
+                                "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" | "2.0.9" => {
                                     info!("Running as {{{}}}", anvil_v_str);
                                     anvil_conf.anvil_kern = AnvilKern::AmbosoC;
                                 }
@@ -1170,7 +1170,7 @@ fn parse_stego_tomlvalue(stego_str: &str, builds_path: &PathBuf, stego_dir: Path
                                     info!("Running as <2.0.4");
                                     anvil_env.anvil_kern = AnvilKern::AmbosoC;
                                 }
-                                "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" => {
+                                "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" | "2.0.9" => {
                                     info!("Running as {{{}}}", anvil_v_str);
                                     anvil_env.anvil_kern = AnvilKern::AmbosoC;
                                 }
@@ -1756,7 +1756,7 @@ pub fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
                             info!("Running as {}", x.as_str());
                             args.anvil_kern = Some(AnvilKern::AmbosoC.to_string());
                         }
-                        "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" => {
+                        "2.0.4" | "2.0.5" | "2.0.6" | "2.0.7" | "2.0.8" | "2.0.9" => {
                             info!("Running as {}", x.as_str());
                         }
                         _ => {

--- a/src/core.rs
+++ b/src/core.rs
@@ -216,6 +216,10 @@ pub struct Args {
     #[arg(short = 'C', long, value_name = "CONFIG_ARG")]
     pub config: Option<String>,
 
+    /// Pass CFLAGS argument
+    #[arg(short = 'Z', long, value_name = "CFLAGS_ARG", allow_hyphen_values = true)]
+    pub cflags: Option<String>,
+
     /// Disable extensions to amboso 2.0
     #[arg(short = 'e', long, default_value = "false")]
     pub strict: bool,
@@ -307,6 +311,9 @@ pub struct AmbosoEnv {
 
     /// String used for configure command argument
     pub configure_arg: String,
+
+    /// String used for CFLAGS
+    pub cflags_arg: String,
 
     /// Allow test mode run
     pub support_testmode: bool,
@@ -1140,6 +1147,7 @@ fn parse_stego_tomlvalue(stego_str: &str, builds_path: &PathBuf, stego_dir: Path
                 do_purge : false,
                 start_time: start_time,
                 configure_arg: "".to_string(),
+                cflags_arg: "".to_string(),
                 anvil_version: EXPECTED_AMBOSO_API_LEVEL.to_string(),
                 enable_extensions: true,
                 anvil_kern: AnvilKern::AmbosoC,
@@ -1722,6 +1730,7 @@ pub fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
         do_purge : false,
         start_time: start_time,
         configure_arg: "".to_string(),
+        cflags_arg: "".to_string(),
         anvil_version: EXPECTED_AMBOSO_API_LEVEL.to_string(),
         enable_extensions: true,
         anvil_kern: AnvilKern::AmbosoC,
@@ -2144,6 +2153,14 @@ pub fn check_passed_args(args: &mut Args) -> Result<AmbosoEnv,String> {
     };
     trace!("{}", makemode_support_text);
 
+    match args.cflags {
+        Some(ref x) => {
+            trace!("Passed CFLAGS: {{{}}}", x);
+            anvil_env.cflags_arg = x.to_string();
+        },
+        None => {}
+    }
+
     debug!("TODO: check if supported tags can be associated with a directory");
 
     if args.git {
@@ -2386,6 +2403,7 @@ pub fn parse_legacy_stego(stego_path: &PathBuf) -> Result<AmbosoEnv,String> {
             do_purge : false,
             start_time: start_time,
             configure_arg: "".to_string(),
+            cflags_arg: "".to_string(),
             anvil_version: EXPECTED_AMBOSO_API_LEVEL.to_string(),
             enable_extensions: true,
             anvil_kern: AnvilKern::AmbosoC,

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,11 @@ fn main() -> ExitCode {
             } else {
                 println!("Experimental anvilPy support is NOT enabled.");
             }
+            if cfg!(feature = "anvilCustom") {
+                println!("Experimental anvilCustom support is enabled.");
+            } else {
+                println!("Experimental anvilCustom support is NOT enabled.");
+            }
         } else {
             println!("{}",INVIL_VERSION);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ mod ops;
 mod utils;
 #[cfg(feature = "anvilPy")]
 mod anvil_py;
+#[cfg(feature = "anvilCustom")]
+mod anvil_custom;
 
 #[macro_use] extern crate log;
 use simplelog::*;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -898,6 +898,10 @@ pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &Strin
                     }
                 }
                 Err(_) => {
+                    if target_tag.len() == 0 {
+                        error!("Invalid empty tag request");
+                        return Err("Invalid empty tag request".to_string());
+                    }
                     warn!("{}", format!("Failed getting tag {target_tag}, retrying using HEAD"));
                     let head = r.head();
                     match head {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1796,6 +1796,11 @@ fn postbuild_step(env: &AmbosoEnv, query: &str, bin_path: PathBuf, build_path: P
         }
         AnvilKern::Custom => {
             #[cfg(feature = "anvilCustom")] {
+                let mut found_bin = true;
+                if !bin_path.exists() {
+                    error!("Can't find {{{}}} after running custom command", bin_path.display());
+                    found_bin = false;
+                }
                 trace!("TODO: postbuild checks for custom kern");
                 match env.run_mode.as_ref().unwrap() {
                     AmbosoMode::GitMode => {
@@ -1803,7 +1808,11 @@ fn postbuild_step(env: &AmbosoEnv, query: &str, bin_path: PathBuf, build_path: P
                         match gswinit_res {
                             Ok(m) => {
                                 trace!("Done git cleaning");
-                                return Ok(m);
+                                if found_bin {
+                                    return Ok(m);
+                                } else {
+                                    return Err("Can't find binary after custom command".to_string());
+                                }
                             }
                             Err(e) => {
                                 error!("git cleaning failed");

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -841,10 +841,10 @@ pub fn run_test(test_path: &PathBuf, record: bool) -> Result<String,String> {
 pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &String) -> Result<String,String> {
     let repo = Repository::discover(target_path);
     let mut head_author_name = "".to_string();
-    let id;
-    let commit_time;
+    let mut id = "".to_string();
     let mut commit_message = "".to_string();
     let gen_time = SystemTime::now();
+    let mut commit_time = "".to_string();
     let gen_timestamp = gen_time.duration_since(SystemTime::UNIX_EPOCH);
     let mut fgen_time = "".to_string();
     match gen_timestamp {
@@ -885,7 +885,7 @@ pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &Strin
                                        warn!("Commit author is empty: {}", head_author_name);
                                    }
                                 }
-                                commit_time = commit.time().seconds();
+                                commit_time = commit.time().seconds().to_string();
                                 info!("Commit time: {{{}}}", commit_time);
                                    }
                             Err(e) => {
@@ -896,8 +896,7 @@ pub fn gen_c_header(target_path: &PathBuf, target_tag: &String, bin_name: &Strin
                     }
                 }
                 Err(_) => {
-                    error!("{}", format!("Failed getting {target_tag}"));
-                    return Err(format!("Failed getting tag {{{target_tag}}}"));
+                    warn!("{}", format!("Failed getting tag {target_tag}"));
                 }
             }
         }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1554,12 +1554,13 @@ fn postbuild_step(env: &AmbosoEnv, query: &str, bin_path: PathBuf) -> Result<Str
             let mut bindir_path = bin_path.clone();
             bindir_path.pop(); // TODO This ensures we move the files to the correct query dir, but it
                                // could be coded in a more explicit way
-            let proj_name = &env.anvilpy_env.as_ref().expect("Failed initialising anvilpy_env").proj_name;
-            let srcdist_name = format!("{}-{}.tar.gz", proj_name, query);
+            let curr_proj_name = env.anvilpy_env.as_ref().expect("Failed initialising anvilpy_env").proj_name.clone().replace("-","_");
+            let srcdist_name = format!("{}-{}.tar.gz", curr_proj_name, query);
             let mut srcdist_path = PathBuf::from("./dist/");
             srcdist_path.push(srcdist_name.clone());
             let move_command_srcdist = format!("mv {} {}", srcdist_path.display(), bindir_path.display());
-            let move_command_whldist = format!("mv ./dist/{}-{}-py3-none-any.whl {}", proj_name.replace("-","_"), query, bindir_path.display());
+            let move_command_whldist = format!("mv ./dist/{}-{}-py3-none-any.whl {}", curr_proj_name, query, bindir_path.display());
+            info!("curr_proj_name {} srcdist_name {}", curr_proj_name, srcdist_name);
             let output_srcdist = Command::new("sh")
                 .arg("-c")
                 .arg(move_command_srcdist)
@@ -1574,7 +1575,7 @@ fn postbuild_step(env: &AmbosoEnv, query: &str, bin_path: PathBuf) -> Result<Str
                         let unpack_res = unpack_srcdist(&srcdist_pack_path);
                         match unpack_res {
                             Ok(unpack_path) => {
-                                let proj_dirname = format!("{proj_name}-{query}");
+                                let proj_dirname = format!("{curr_proj_name}-{query}");
                                 let mut target_unpack_path = unpack_path.clone();
                                 target_unpack_path.push(ANVILPY_UNPACKDIR_NAME);
                                 let mut curr_unpack_path = unpack_path.clone();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -166,17 +166,12 @@ pub fn do_build(env: &AmbosoEnv, args: &Args) -> Result<String,String> {
                             source_path.push(env.source.clone().unwrap());
                             let mut bin_path = build_path.clone();
                             bin_path.push(env.bin.clone().unwrap());
-                            let cflg = "CFLAGS";
                             let cflg_str;
-                            match env::var(cflg) {
-                                Ok(val) => {
-                                    debug!("Using {{{}: {}}}", cflg, val);
-                                    cflg_str = format!("CFLAGS={}", &val);
-                                },
-                                Err(e) => {
-                                    debug!("Failed reading {{{}: {}}}", cflg, e);
-                                    cflg_str = "".to_string();
-                                }
+                            if env.cflags_arg.len() > 0 {
+                                debug!("Using passed CFLAGS {{{}}}", env.cflags_arg);
+                                cflg_str = env.cflags_arg.clone();
+                            } else {
+                                cflg_str = "".to_string()
                             }
                             let cc = "CC";
                             let cc_str;
@@ -198,9 +193,11 @@ pub fn do_build(env: &AmbosoEnv, args: &Args) -> Result<String,String> {
                                     .output()
                                     .expect("failed to execute process")
                             } else {
+                                let single_mode_cmd = format!("{} {} {} -o {} -lm", cc_str, cflg_str, source_path.display(), bin_path.display());
+                                trace!("Using single file mode: {{{}}}", single_mode_cmd);
                                 Command::new("sh")
                                     .arg("-c")
-                                    .arg(format!("{} {} {} -o {} -lm", cflg_str, cc_str, source_path.display(), bin_path.display()))
+                                    .arg(single_mode_cmd)
                                     .output()
                                     .expect("failed to execute process")
                             }
@@ -211,17 +208,12 @@ pub fn do_build(env: &AmbosoEnv, args: &Args) -> Result<String,String> {
                             source_path.push(env.source.clone().unwrap());
                             let mut bin_path = build_path.clone();
                             bin_path.push(env.bin.clone().unwrap());
-                            let cflg = "CFLAGS";
                             let cflg_str;
-                            match env::var(cflg) {
-                                Ok(val) => {
-                                    debug!("Using {{{}: {}}}", cflg, val);
-                                    cflg_str = format!("CFLAGS={}", &val);
-                                },
-                                Err(e) => {
-                                    debug!("Failed reading {{{}: {}}}", cflg, e);
-                                    cflg_str = "".to_string();
-                                }
+                            if env.cflags_arg.len() > 0 {
+                                debug!("Using passed CFLAGS{{{}}}", env.cflags_arg);
+                                cflg_str = env.cflags_arg.clone();
+                            } else {
+                                cflg_str = "".to_string()
                             }
                             trace!("Git mode, checking out {}",query);
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -167,11 +167,21 @@ pub fn do_build(env: &AmbosoEnv, args: &Args) -> Result<String,String> {
                             let mut bin_path = build_path.clone();
                             bin_path.push(env.bin.clone().unwrap());
                             let cflg_str;
-                            if env.cflags_arg.len() > 0 {
+                            if env.cflags_arg.len() > 0 { //We have the arg from --config/-Z
                                 debug!("Using passed CFLAGS {{{}}}", env.cflags_arg);
                                 cflg_str = env.cflags_arg.clone();
-                            } else {
-                                cflg_str = "".to_string()
+                            } else { //Backcomp reading env CFLAGS
+                                let cflags = "CFLAGS";
+                                match env::var(cflags) {
+                                    Ok(val) => {
+                                        debug!("Using {{{}: {}}}", cflags, val);
+                                        cflg_str = format!("{}",val);
+                                    },
+                                    Err(e) => {
+                                        error!("Failed reading {{{}: {}}}", cflags, e);
+                                        cflg_str = "".to_string()
+                                    }
+                                }
                             }
                             let cc = "CC";
                             let cc_str;


### PR DESCRIPTION
### Added

- Add `-Z` to pass `CFLAGS` to single file build mode
  - Avoids reading `CFLAGS` from env
- Basic optional support for `AnvilCustom` kern
  - Improves #170 

### Changed

- Fix: avoid error on wrong tag for `-G`, mimicking amboso
- Try reading `AMBOSO_CONFIG_ARG_ISFILE` to use `-C` with flags directly
  - Setting it to `0` enables the new, backwards incompatible behaviour
- Fix `anvilPy` build op not replacing dashes as expected
  - Closes #190 
- Fix `anvilPy` build op going to `autotools` prep when query `>= ANVIL_AUTOMAKE_VERS`
  - Closes #191 
- Fix `anvilPy` build op going to single-file C mode when query `<= ANVIL_MAKE_VERS`
  - Closes #192 
- Bump expected amboso version to `2.0.9`